### PR TITLE
Add WASM/JS support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,24 +9,28 @@ env:
 
 jobs:
   test:
-    name: Test Go ${{ matrix.go }}/PHP ${{ matrix.php }}/Dart ${{ matrix.dart }} on ${{ matrix.os }}
+    name: "Tests: Go ${{ matrix.go }}/Dart ${{ matrix.dart }}/Node ${{ matrix.node }}/PHP ${{ matrix.php }} on ${{ matrix.os }}"
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
         go:
-          - ~1.19.0
-          - ~1.18.0
-          - ~1.17.0
+          - '1.19'
+          - '1.18'
+          - '1.17'
+        dart:
+          - stable
+        node:
+          - 18
+          - 16
         php:
           - '8.2'
           - '8.1'
           - '8.0'
           - '7.4'
-        dart:
-          - stable
         include:
           - os: ubuntu-latest
             ext: so
@@ -43,6 +47,17 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.dart }}
+
+      - name: Setup Node
+        if: ${{ matrix.go == 1.19 }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         id: php
@@ -51,10 +66,11 @@ jobs:
           coverage: none
           extensions: ffi
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: ${{ matrix.dart }}
+      - name: Local Dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' && github.actor == 'nektos/act' }}
+        run: |
+          apt-get update
+          apt-get install -y wget
 
       - name: Run Go tests (Not Windows)
         if: ${{ matrix.os != 'windows-latest' }}
@@ -65,10 +81,32 @@ jobs:
         run: pwsh ./tests/go.ps1
 
       - name: Test building libcalends
-        run: go build -v -o libcalends.out -buildmode=c-shared ./libcalends
+        run: go build -v -o libcalends.${{ matrix.ext }} -buildmode=c-shared ./libcalends
 
       - name: Test building cli
         run: go build -v -o calends.out ./cli
+
+      - name: Test building WASM
+        if: ${{ matrix.go == 1.19 }}
+        run: go build -v -o calends.wasm ./wasm
+        env:
+          GOOS: js
+          GOARCH: wasm
+
+      - name: Test Dart wrapper
+        run: |
+          cp libcalends.${{ matrix.ext }} libcalends/dart/
+          cd libcalends/dart
+          dart pub get
+          dart test
+
+      - name: Test WASM via JS wrapper
+        if: ${{ matrix.go == 1.19 }}
+        run: |
+          cp calends.wasm wasm/js/
+          cd wasm/js
+          npm ci
+          npm test
 
       - name: Test PHP wrapper (Not Windows)
         if: ${{ matrix.os != 'windows-latest' }}
@@ -77,12 +115,6 @@ jobs:
       - name: Test PHP wrapper (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: pwsh ./tests/php.ps1 ${{ steps.php.outputs.php-version }} ${{ matrix.ext }}
-
-      - name: Test Dart wrapper
-        run: |
-          cd libcalends/dart
-          dart pub get
-          dart test
 
   build:
     name: Build Binaries
@@ -94,7 +126,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.19'
 
       - name: Build binaries
         run: ./build-all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           sdk: ${{ matrix.dart }}
 
       - name: Setup Node
-        if: ${{ matrix.go == 1.19 }}
+        if: ${{ matrix.go == '1.19' }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
@@ -65,6 +65,8 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
           extensions: ffi
+        env:
+          update: true
 
       - name: Local Dependencies
         if: ${{ matrix.os == 'ubuntu-latest' && github.actor == 'nektos/act' }}
@@ -87,7 +89,7 @@ jobs:
         run: go build -v -o calends.out ./cli
 
       - name: Test building WASM
-        if: ${{ matrix.go == 1.19 }}
+        if: ${{ matrix.go == '1.19' }}
         run: go build -v -o calends.wasm ./wasm
         env:
           GOOS: js
@@ -101,7 +103,7 @@ jobs:
           dart test
 
       - name: Test WASM via JS wrapper
-        if: ${{ matrix.go == 1.19 }}
+        if: ${{ matrix.go == '1.19' }}
         run: |
           cp calends.wasm wasm/js/
           cd wasm/js
@@ -130,6 +132,12 @@ jobs:
 
       - name: Build binaries
         run: ./build-all
+
+      - name: Upload binaries as assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: builds
+          path: dist/*
 
       - name: Release binaries
         if: startsWith(github.ref, 'refs/tags/')

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ core*
 *.dep
 /vendor/
 !/vendor/modules.txt
+wasm/**/*.wasm

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Daniel Hunsaker
+Copyright (c) 2018-2023 Daniel Hunsaker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build-all
+++ b/build-all
@@ -41,7 +41,7 @@ do
 
   if [ -e ${dir}/libcalends.dll ]
   then
-    zip ${dir}.zip ${dir}/*
+    zip -j ${dir}.zip ${dir}/*
   else
     tar czvf ${dir}.tgz -C ${dir} .
   fi

--- a/build-all
+++ b/build-all
@@ -14,7 +14,7 @@ go mod vendor
 go install github.com/crazy-max/xgo@latest
 ${GOPATH}/bin/xgo -buildmode=c-shared -dest=$(pwd)/dist/ -out=libcalends-${VERSION} -targets=${TARGETS} github.com/danhunsaker/calends/libcalends
 ${GOPATH}/bin/xgo -dest=$(pwd)/dist/bin/ -out=calends-${VERSION} -targets=${TARGETS} ./cli
-GOOS=js GOARCH=wasm go build -o=$(pwd)/dist/calends-${VERSION}.wasm github.com/danhunsaker/calends
+GOOS=js GOARCH=wasm go build -o=$(pwd)/dist/calends-${VERSION}.wasm github.com/danhunsaker/calends/wasm
 
 for h in $(find dist/ -name '*.h')
 do

--- a/calendars/0calendars.go
+++ b/calendars/0calendars.go
@@ -3,7 +3,7 @@
 /*
 
 It provides an interface for custom calendar systems to implement, and a data
-type for storing instants in the internal TAI64NAXUR format, so that the various
+type for storing instants in the internal TAI64NARUX format, so that the various
 date/time manipulation functions of Calends can easily operate on them. It also
 provides a handful of utility functions and methods to simplify the conversion
 process between the calendar system and the internal format.
@@ -24,20 +24,20 @@ import (
 
 // CalendarDefinition is the primary interface for defining calendar systems.
 type CalendarDefinition interface {
-	// Convert a date representation to an internal TAI64NAXURTime
-	ToInternal(interface{}, string) (TAI64NAXURTime, error)
+	// Convert a date representation to an internal TAI64NARUXTime
+	ToInternal(interface{}, string) (TAI64NARUXTime, error)
 
-	// Convert an internal TAI64NAXURTime to a date representation
-	FromInternal(TAI64NAXURTime, string) (string, error)
+	// Convert an internal TAI64NARUXTime to a date representation
+	FromInternal(TAI64NARUXTime, string) (string, error)
 
-	// Calculate the TAI64NAXURTime at a given offset from another TAI64NAXURTime
-	Offset(TAI64NAXURTime, interface{}) (TAI64NAXURTime, error)
+	// Calculate the TAI64NARUXTime at a given offset from another TAI64NARUXTime
+	Offset(TAI64NARUXTime, interface{}) (TAI64NARUXTime, error)
 }
 
 type calendarRegistration struct {
-	ToInternal    func(interface{}, string) (TAI64NAXURTime, error)
-	FromInternal  func(TAI64NAXURTime, string) (string, error)
-	Offset        func(TAI64NAXURTime, interface{}) (TAI64NAXURTime, error)
+	ToInternal    func(interface{}, string) (TAI64NARUXTime, error)
+	FromInternal  func(TAI64NARUXTime, string) (string, error)
+	Offset        func(TAI64NARUXTime, interface{}) (TAI64NARUXTime, error)
 	DefaultFormat string
 }
 
@@ -75,9 +75,9 @@ and saves `defaultFormat` for later use while parsing or formatting.
 */
 func RegisterElements(
 	name string,
-	toInternal func(interface{}, string) (TAI64NAXURTime, error),
-	fromInternal func(TAI64NAXURTime, string) (string, error),
-	offset func(TAI64NAXURTime, interface{}) (TAI64NAXURTime, error),
+	toInternal func(interface{}, string) (TAI64NARUXTime, error),
+	fromInternal func(TAI64NARUXTime, string) (string, error),
+	offset func(TAI64NARUXTime, interface{}) (TAI64NARUXTime, error),
 	defaultFormat string,
 ) {
 	registeredCalendars[canonCalendarName(name)] = calendarRegistration{
@@ -123,9 +123,9 @@ func DefaultFormat(calendar string) string {
 }
 
 // ToInternal returns the associated value from a registered calendar system.
-func ToInternal(calendar string, date interface{}, format string) (TAI64NAXURTime, error) {
+func ToInternal(calendar string, date interface{}, format string) (TAI64NARUXTime, error) {
 	if !Registered(calendar) {
-		return TAI64NAXURTime{}, errors.Wrap(ErrUnknownCalendar(calendar), 1)
+		return TAI64NARUXTime{}, errors.Wrap(ErrUnknownCalendar(calendar), 1)
 	}
 
 	if format == "" {
@@ -143,7 +143,7 @@ func ToInternal(calendar string, date interface{}, format string) (TAI64NAXURTim
 }
 
 // FromInternal returns the associated value from a registered calendar system.
-func FromInternal(calendar string, stamp TAI64NAXURTime, format string) (string, error) {
+func FromInternal(calendar string, stamp TAI64NARUXTime, format string) (string, error) {
 	if !Registered(calendar) {
 		return "", errors.Wrap(ErrUnknownCalendar(calendar), 1)
 	}
@@ -163,9 +163,9 @@ func FromInternal(calendar string, stamp TAI64NAXURTime, format string) (string,
 }
 
 // Offset returns the associated value from a registered calendar system.
-func Offset(calendar string, stamp TAI64NAXURTime, offset interface{}) (TAI64NAXURTime, error) {
+func Offset(calendar string, stamp TAI64NARUXTime, offset interface{}) (TAI64NARUXTime, error) {
 	if !Registered(calendar) {
-		return TAI64NAXURTime{}, errors.Wrap(ErrUnknownCalendar(calendar), 1)
+		return TAI64NARUXTime{}, errors.Wrap(ErrUnknownCalendar(calendar), 1)
 	}
 
 	out, err := registeredCalendars[canonCalendarName(calendar)].Offset(stamp, offset)

--- a/calendars/0calendars_test.go
+++ b/calendars/0calendars_test.go
@@ -13,29 +13,29 @@ type testCalendarClass struct {
 	DefaultFormat string
 }
 
-func (testCalendarClass) ToInternal(in interface{}, mod string) (out TAI64NAXURTime, err error) {
+func (testCalendarClass) ToInternal(in interface{}, mod string) (out TAI64NARUXTime, err error) {
 	err = errors.New("testToInternal")
 	return
 }
 
-func (testCalendarClass) FromInternal(in TAI64NAXURTime, mod string) (out string, err error) {
+func (testCalendarClass) FromInternal(in TAI64NARUXTime, mod string) (out string, err error) {
 	err = errors.New("testFromInternal")
 	return
 }
 
-func (testCalendarClass) Offset(in TAI64NAXURTime, mod interface{}) (out TAI64NAXURTime, err error) {
+func (testCalendarClass) Offset(in TAI64NARUXTime, mod interface{}) (out TAI64NARUXTime, err error) {
 	err = errors.New("testOffset")
 	return
 }
 
 func init() {
-	testCalendarElements.ToInternal = func(in interface{}, mod string) (out TAI64NAXURTime, err error) {
+	testCalendarElements.ToInternal = func(in interface{}, mod string) (out TAI64NARUXTime, err error) {
 		return
 	}
-	testCalendarElements.FromInternal = func(in TAI64NAXURTime, mod string) (out string, err error) {
+	testCalendarElements.FromInternal = func(in TAI64NARUXTime, mod string) (out string, err error) {
 		return
 	}
-	testCalendarElements.Offset = func(in TAI64NAXURTime, mod interface{}) (out TAI64NAXURTime, err error) {
+	testCalendarElements.Offset = func(in TAI64NARUXTime, mod interface{}) (out TAI64NARUXTime, err error) {
 		return
 	}
 	testCalendarElements.DefaultFormat = "test"
@@ -146,13 +146,13 @@ func TestFromInternal(t *testing.T) {
 		TestRegistered(t)
 	}
 
-	_, err := FromInternal("testCalendar", TAI64NAXURTime{}, "")
+	_, err := FromInternal("testCalendar", TAI64NARUXTime{}, "")
 
 	if err == nil || err.Error() != "testFromInternal" {
-		t.Errorf("FromInternal(\"testCalendar\", TAI64NAXURTime{}, \"\") failed - got %#v, but wanted %#v", err.Error(), "testFromInternal")
+		t.Errorf("FromInternal(\"testCalendar\", TAI64NARUXTime{}, \"\") failed - got %#v, but wanted %#v", err.Error(), "testFromInternal")
 	}
 
-	_, err = FromInternal("invalid", TAI64NAXURTime{}, "")
+	_, err = FromInternal("invalid", TAI64NARUXTime{}, "")
 
 	if err.Error() != ErrUnknownCalendar("invalid").Error() {
 		t.Errorf("FromInternal(\"invalid\", \"\", \"\") failed - got %q, but wanted %q", err, ErrUnknownCalendar("invalid"))
@@ -164,13 +164,13 @@ func TestOffset(t *testing.T) {
 		TestRegistered(t)
 	}
 
-	_, err := Offset("testCalendar", TAI64NAXURTime{}, "")
+	_, err := Offset("testCalendar", TAI64NARUXTime{}, "")
 
 	if err == nil || err.Error() != "testOffset" {
-		t.Errorf("Offset(\"testCalendar\", TAI64NAXURTime{}, \"\") failed - got %#v, but wanted %#v", err.Error(), "testOffset")
+		t.Errorf("Offset(\"testCalendar\", TAI64NARUXTime{}, \"\") failed - got %#v, but wanted %#v", err.Error(), "testOffset")
 	}
 
-	_, err = Offset("invalid", TAI64NAXURTime{}, "")
+	_, err = Offset("invalid", TAI64NARUXTime{}, "")
 
 	if err.Error() != ErrUnknownCalendar("invalid").Error() {
 		t.Errorf("Offset(\"invalid\", \"\", \"\") failed - got %q, but wanted %q", err, ErrUnknownCalendar("invalid"))

--- a/calendars/0internal.go
+++ b/calendars/0internal.go
@@ -6,25 +6,25 @@ import (
 	"math/big"
 )
 
-// TAI64NAXURTime stores a TAI64NAXUR instant in a reliable, easy-converted
+// TAI64NARUXTime stores a TAI64NARUX instant in a reliable, easy-converted
 // format.
-type TAI64NAXURTime struct {
-	Seconds int64  // Seconds since 1970-01-01 00:00:00 TAI
-	Nano    uint32 // Nanoseconds since the given second
-	Atto    uint32 // Attoseconds since the given nanosecond
-	Xicto   uint32 // Xictoseconds since the given attosecond
-	Ucto    uint32 // Uctoseconds since the given xictosecond
-	Rocto   uint32 // Roctoseconds since the given uctosecond
+type TAI64NARUXTime struct {
+	Seconds  int64  // Seconds since 1970-01-01 00:00:00 TAI
+	Nano     uint32 // billionths of a second since the given second
+	Atto     uint32 // billionths of a nanosecond since the given nanosecond
+	Ronto    uint32 // billionths of an attosecond since the given attosecond
+	Udecto   uint32 // billionths of a rontosecond since the given rontosecond
+	Xindecto uint32 // billionths of an udectosecond since the given udectosecond
 }
 
-// Add calculates the sum of two TAI64NAXURTime values.
-func (t TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime {
-	var o TAI64NAXURTime
+// Add calculates the sum of two TAI64NARUXTime values.
+func (t TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime {
+	var o TAI64NARUXTime
 	var roll int32
 
-	roll, o.Rocto = rollOverAt9(int32(t.Rocto + z.Rocto))
-	roll, o.Ucto = rollOverAt9(int32(t.Ucto+z.Ucto) + roll)
-	roll, o.Xicto = rollOverAt9(int32(t.Xicto+z.Xicto) + roll)
+	roll, o.Xindecto = rollOverAt9(int32(t.Xindecto + z.Xindecto))
+	roll, o.Udecto = rollOverAt9(int32(t.Udecto+z.Udecto) + roll)
+	roll, o.Ronto = rollOverAt9(int32(t.Ronto+z.Ronto) + roll)
 	roll, o.Atto = rollOverAt9(int32(t.Atto+z.Atto) + roll)
 	roll, o.Nano = rollOverAt9(int32(t.Nano+z.Nano) + roll)
 	o.Seconds = t.Seconds + z.Seconds + int64(roll)
@@ -32,14 +32,14 @@ func (t TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime {
 	return o
 }
 
-// Sub calculates the difference of two TAI64NAXURTime values.
-func (t TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime {
-	var o TAI64NAXURTime
+// Sub calculates the difference of two TAI64NARUXTime values.
+func (t TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime {
+	var o TAI64NARUXTime
 	var roll int32
 
-	roll, o.Rocto = rollOverAt9(int32(t.Rocto) - int32(z.Rocto))
-	roll, o.Ucto = rollOverAt9(int32(t.Ucto) - int32(z.Ucto) - roll)
-	roll, o.Xicto = rollOverAt9(int32(t.Xicto) - int32(z.Xicto) - roll)
+	roll, o.Xindecto = rollOverAt9(int32(t.Xindecto) - int32(z.Xindecto))
+	roll, o.Udecto = rollOverAt9(int32(t.Udecto) - int32(z.Udecto) - roll)
+	roll, o.Ronto = rollOverAt9(int32(t.Ronto) - int32(z.Ronto) - roll)
 	roll, o.Atto = rollOverAt9(int32(t.Atto) - int32(z.Atto) - roll)
 	roll, o.Nano = rollOverAt9(int32(t.Nano) - int32(z.Nano) - roll)
 	o.Seconds = t.Seconds - z.Seconds - int64(roll)
@@ -47,39 +47,39 @@ func (t TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime {
 	return o
 }
 
-// String returns the decimal string representation of the TAI64NAXURTime value.
-func (t TAI64NAXURTime) String() string {
+// String returns the decimal string representation of the TAI64NARUXTime value.
+func (t TAI64NARUXTime) String() string {
 	out, _ := FromInternal("tai64", t, "decimal")
 	return out
 }
 
-// HexString returns the hex string representation of the TAI64NAXURTime value.
-func (t TAI64NAXURTime) HexString() string {
-	out, _ := FromInternal("tai64", t, "tai64naxur")
+// HexString returns the hex string representation of the TAI64NARUXTime value.
+func (t TAI64NARUXTime) HexString() string {
+	out, _ := FromInternal("tai64", t, "tai64narux")
 	return out
 }
 
-// Float returns the math/big.Float representation of the TAI64NAXURTime value.
-func (t TAI64NAXURTime) Float() *big.Float {
+// Float returns the math/big.Float representation of the TAI64NARUXTime value.
+func (t TAI64NARUXTime) Float() *big.Float {
 	out, _, _ := big.ParseFloat(t.String(), 10, 176, big.ToNearestAway)
 	return out
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.
-func (t TAI64NAXURTime) MarshalText() ([]byte, error) {
-	out, err := FromInternal("tai64", t, "tai64naxur")
+func (t TAI64NARUXTime) MarshalText() ([]byte, error) {
+	out, err := FromInternal("tai64", t, "tai64narux")
 	return []byte(out), err
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
-func (t *TAI64NAXURTime) UnmarshalText(in []byte) error {
-	tmp, err := ToInternal("tai64", in, "tai64naxur")
+func (t *TAI64NARUXTime) UnmarshalText(in []byte) error {
+	tmp, err := ToInternal("tai64", in, "tai64narux")
 	*t = tmp
 	return err
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
-func (t *TAI64NAXURTime) MarshalBinary() (out []byte, err error) {
+func (t *TAI64NARUXTime) MarshalBinary() (out []byte, err error) {
 	in, err := t.MarshalText()
 	if err != nil {
 		return
@@ -91,33 +91,33 @@ func (t *TAI64NAXURTime) MarshalBinary() (out []byte, err error) {
 }
 
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
-func (t *TAI64NAXURTime) UnmarshalBinary(in []byte) error {
+func (t *TAI64NARUXTime) UnmarshalBinary(in []byte) error {
 	out := hex.EncodeToString(in)
 
 	return t.UnmarshalText([]byte(out))
 }
 
-// TAI64NAXURTimeFromDecimalString calculates a TAI64NAXURTime from its decimal
+// TAI64NARUXTimeFromDecimalString calculates a TAI64NARUXTime from its decimal
 // string representation.
-func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime {
+func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime {
 	out, _ := ToInternal("tai64", in, "decimal")
-	// fmt.Printf("TAI64NAXURTimeFromDecimalString: %#v → %#v [%#v]\n", in, out, err)
+	// fmt.Printf("TAI64NARUXTimeFromDecimalString: %#v → %#v [%#v]\n", in, out, err)
 	return out
 }
 
-// TAI64NAXURTimeFromHexString calculates a TAI64NAXURTime from its hexadecimal
+// TAI64NARUXTimeFromHexString calculates a TAI64NARUXTime from its hexadecimal
 // string representation.
-func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime {
-	out, _ := ToInternal("tai64", in, "tai64naxur")
-	// fmt.Printf("TAI64NAXURTimeFromHexString: %#v → %#v [%#v]\n", in, out, err)
+func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime {
+	out, _ := ToInternal("tai64", in, "tai64narux")
+	// fmt.Printf("TAI64NARUXTimeFromHexString: %#v → %#v [%#v]\n", in, out, err)
 	return out
 }
 
-// TAI64NAXURTimeFromFloat calculates a TAI64NAXURTime from its math/big.Float
+// TAI64NARUXTimeFromFloat calculates a TAI64NARUXTime from its math/big.Float
 // representation.
-func TAI64NAXURTimeFromFloat(in big.Float) TAI64NAXURTime {
-	// fmt.Printf("TAI64NAXURTimeFromFloat: %#v\n", in)
-	return TAI64NAXURTimeFromDecimalString(in.Text('f', 45))
+func TAI64NARUXTimeFromFloat(in big.Float) TAI64NARUXTime {
+	// fmt.Printf("TAI64NARUXTimeFromFloat: %#v\n", in)
+	return TAI64NARUXTimeFromDecimalString(in.Text('f', 45))
 }
 
 func rollOverAt9(value int32) (roll int32, remain uint32) {

--- a/calendars/0internal_test.go
+++ b/calendars/0internal_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
-	and := TAI64NAXURTime{Seconds: 2}
-	want := TAI64NAXURTime{Seconds: 3}
+	in := TAI64NARUXTime{Seconds: 1}
+	and := TAI64NARUXTime{Seconds: 2}
+	want := TAI64NARUXTime{Seconds: 3}
 	got := in.Add(and)
 
 	if got != want {
@@ -17,9 +17,9 @@ func TestAdd(t *testing.T) {
 }
 
 func TestSub(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
-	and := TAI64NAXURTime{Seconds: 2}
-	want := TAI64NAXURTime{Seconds: -1}
+	in := TAI64NARUXTime{Seconds: 1}
+	and := TAI64NARUXTime{Seconds: 2}
+	want := TAI64NARUXTime{Seconds: -1}
 	got := in.Sub(and)
 
 	if got != want {
@@ -28,7 +28,7 @@ func TestSub(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
+	in := TAI64NARUXTime{Seconds: 1}
 	want := "1"
 	got := in.String()
 
@@ -38,7 +38,7 @@ func TestString(t *testing.T) {
 }
 
 func TestHexString(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
+	in := TAI64NARUXTime{Seconds: 1}
 	want := "40000000000000010000000000000000000000000000000000000000"
 	got := in.HexString()
 
@@ -48,7 +48,7 @@ func TestHexString(t *testing.T) {
 }
 
 func TestFloat(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
+	in := TAI64NARUXTime{Seconds: 1}
 	want := big.NewFloat(1)
 	got := in.Float()
 
@@ -58,7 +58,7 @@ func TestFloat(t *testing.T) {
 }
 
 func TestMarshalText(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
+	in := TAI64NARUXTime{Seconds: 1}
 	want := "40000000000000010000000000000000000000000000000000000000"
 	got, _ := in.MarshalText()
 
@@ -68,9 +68,9 @@ func TestMarshalText(t *testing.T) {
 }
 
 func TestUnmarshalText(t *testing.T) {
-	var got TAI64NAXURTime
+	var got TAI64NARUXTime
 	in := []byte("40000000000000010000000000000000000000000000000000000000")
-	want := TAI64NAXURTime{Seconds: 1}
+	want := TAI64NARUXTime{Seconds: 1}
 	got.UnmarshalText(in)
 
 	if got != want {
@@ -79,7 +79,7 @@ func TestUnmarshalText(t *testing.T) {
 }
 
 func TestMarshalBinary(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
+	in := TAI64NARUXTime{Seconds: 1}
 	want := "@\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 	got, _ := in.MarshalBinary()
 
@@ -89,9 +89,9 @@ func TestMarshalBinary(t *testing.T) {
 }
 
 func TestUnmarshalBinary(t *testing.T) {
-	var got TAI64NAXURTime
+	var got TAI64NARUXTime
 	in := []byte("@\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-	want := TAI64NAXURTime{Seconds: 1}
+	want := TAI64NARUXTime{Seconds: 1}
 	got.UnmarshalBinary(in)
 
 	if got != want {
@@ -99,33 +99,33 @@ func TestUnmarshalBinary(t *testing.T) {
 	}
 }
 
-func TestTAI64NAXURTimeFromDecimalString(t *testing.T) {
+func TestTAI64NARUXTimeFromDecimalString(t *testing.T) {
 	in := "1"
-	want := TAI64NAXURTime{Seconds: 1}
-	got := TAI64NAXURTimeFromDecimalString(in)
+	want := TAI64NARUXTime{Seconds: 1}
+	got := TAI64NARUXTimeFromDecimalString(in)
 
 	if got != want {
-		t.Errorf("TAI64NAXURTimeFromDecimalString(%#v) failed\ngot  %#v\nwant %#v", in, got, want)
+		t.Errorf("TAI64NARUXTimeFromDecimalString(%#v) failed\ngot  %#v\nwant %#v", in, got, want)
 	}
 }
 
-func TestTAI64NAXURTimeFromHexString(t *testing.T) {
+func TestTAI64NARUXTimeFromHexString(t *testing.T) {
 	in := "40000000000000010000000000000000000000000000000000000000"
-	want := TAI64NAXURTime{Seconds: 1}
-	got := TAI64NAXURTimeFromHexString(in)
+	want := TAI64NARUXTime{Seconds: 1}
+	got := TAI64NARUXTimeFromHexString(in)
 
 	if got != want {
-		t.Errorf("TAI64NAXURTimeFromHexString(%#v) failed\ngot  %#v\nwant %#v", in, got, want)
+		t.Errorf("TAI64NARUXTimeFromHexString(%#v) failed\ngot  %#v\nwant %#v", in, got, want)
 	}
 }
 
-func TestTAI64NAXURTimeFromFloat(t *testing.T) {
+func TestTAI64NARUXTimeFromFloat(t *testing.T) {
 	in := *big.NewFloat(1)
-	want := TAI64NAXURTime{Seconds: 1}
-	got := TAI64NAXURTimeFromFloat(in)
+	want := TAI64NARUXTime{Seconds: 1}
+	got := TAI64NARUXTimeFromFloat(in)
 
 	if got != want {
-		t.Errorf("TAI64NAXURTimeFromFloat(%#v) failed\ngot  %#v\nwant %#v", in, got, want)
+		t.Errorf("TAI64NARUXTimeFromFloat(%#v) failed\ngot  %#v\nwant %#v", in, got, want)
 	}
 }
 

--- a/calendars/0leapseconds.go
+++ b/calendars/0leapseconds.go
@@ -127,8 +127,8 @@ func init() {
 	gob.NewDecoder(base64.NewDecoder(base64.StdEncoding, strings.NewReader(encoded))).Decode(&leapSeconds)
 }
 
-// UTCtoTAI removes the UTC leap second offset from a TAI64NAXURTime value.
-func UTCtoTAI(utc TAI64NAXURTime) (tai TAI64NAXURTime) {
+// UTCtoTAI removes the UTC leap second offset from a TAI64NARUXTime value.
+func UTCtoTAI(utc TAI64NARUXTime) (tai TAI64NARUXTime) {
 	// Calculate year, month, day
 	oldYear, oldMonth, oldDay := time.Unix(utc.Seconds, int64(utc.Nano)).UTC().Date()
 	// Remove the leap second offset
@@ -145,8 +145,8 @@ func UTCtoTAI(utc TAI64NAXURTime) (tai TAI64NAXURTime) {
 	return
 }
 
-// TAItoUTC adds the UTC leap second offset to a TAI64NAXURTime value.
-func TAItoUTC(tai TAI64NAXURTime) (utc TAI64NAXURTime) {
+// TAItoUTC adds the UTC leap second offset to a TAI64NARUXTime value.
+func TAItoUTC(tai TAI64NARUXTime) (utc TAI64NARUXTime) {
 	// Calculate year, month, day
 	year, month, day := time.Unix(tai.Seconds, int64(tai.Nano)).UTC().Date()
 	// Add the leap second offset
@@ -155,7 +155,7 @@ func TAItoUTC(tai TAI64NAXURTime) (utc TAI64NAXURTime) {
 	return
 }
 
-func getTAIOffset(year int, month time.Month, day int) (offset TAI64NAXURTime) {
+func getTAIOffset(year int, month time.Month, day int) (offset TAI64NARUXTime) {
 	const baseDay = 40587 //Modified Julian Date at January 1, 1970
 
 	var entry *leapSecondOffset
@@ -174,7 +174,7 @@ func getTAIOffset(year int, month time.Month, day int) (offset TAI64NAXURTime) {
 	timestamp := time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Unix()
 	mjd := int(timestamp/86400 + baseDay)
 
-	offset = TAI64NAXURTimeFromFloat(*big.NewFloat(entry.Offset + entry.Modifier.Calculate(mjd)))
+	offset = TAI64NARUXTimeFromFloat(*big.NewFloat(entry.Offset + entry.Modifier.Calculate(mjd)))
 
 	return
 }

--- a/calendars/0leapseconds_test.go
+++ b/calendars/0leapseconds_test.go
@@ -27,8 +27,8 @@ func TestLeapSecondDateCompare(t *testing.T) {
 }
 
 func TestUTCtoTAI(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
-	want := TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598")
+	in := TAI64NARUXTime{Seconds: 1}
+	want := TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598")
 	got := UTCtoTAI(in)
 
 	if got != want {
@@ -37,8 +37,8 @@ func TestUTCtoTAI(t *testing.T) {
 }
 
 func TestTAItoUTC(t *testing.T) {
-	in := TAI64NAXURTime{Seconds: 1}
-	want := TAI64NAXURTimeFromDecimalString("9.000081999999999027295416453853249549865722656")
+	in := TAI64NARUXTime{Seconds: 1}
+	want := TAI64NARUXTimeFromDecimalString("9.000081999999999027295416453853249549865722656")
 	got := TAItoUTC(in)
 
 	if got != want {
@@ -48,7 +48,7 @@ func TestTAItoUTC(t *testing.T) {
 
 func TestGetTAIOffset(t *testing.T) {
 	year, month, day := 1970, time.January, 1
-	want := TAI64NAXURTimeFromDecimalString("8.000081999999999027295416453853249549865722656")
+	want := TAI64NARUXTimeFromDecimalString("8.000081999999999027295416453853249549865722656")
 	got := getTAIOffset(year, month, day)
 
 	if got != want {

--- a/calendars/gregorian.go
+++ b/calendars/gregorian.go
@@ -33,7 +33,7 @@ func init() {
 		// name
 		"gregorian",
 		// toInternal
-		func(date interface{}, format string) (stamp TAI64NAXURTime, err error) {
+		func(date interface{}, format string) (stamp TAI64NARUXTime, err error) {
 			var in time.Time
 			var str string
 
@@ -66,7 +66,7 @@ func init() {
 			return
 		},
 		// fromInternal
-		func(stamp TAI64NAXURTime, format string) (date string, err error) {
+		func(stamp TAI64NARUXTime, format string) (date string, err error) {
 			tmp := time.Unix(stamp.Seconds, int64(stamp.Nano)).UTC()
 			if strings.ContainsRune(format, '%') {
 				date, err = strtime.Strftime(tmp, format)
@@ -77,7 +77,7 @@ func init() {
 			return
 		},
 		// offset
-		func(in TAI64NAXURTime, offset interface{}) (out TAI64NAXURTime, err error) {
+		func(in TAI64NARUXTime, offset interface{}) (out TAI64NARUXTime, err error) {
 			var str string
 
 			switch offset.(type) {

--- a/calendars/gregorian_test.go
+++ b/calendars/gregorian_test.go
@@ -7,16 +7,16 @@ import (
 
 func TestGregorianToInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{"Thu, 01 Jan 1970 00:00:01 UTC", ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{"1970-01-01 00:00:01 UTC", "2006-01-02 15:04:05 MST"}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{"1970-01-01 00:00:01 UTC", "%Y-%m-%d %H:%M:%S %Z"}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{[]byte("Thu, 01 Jan 1970 00:00:01 UTC"), ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{time.Unix(1, 0).UTC(), ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{"Thu, 01 Jan 1970 00:00:01 UTC", ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{"1970-01-01 00:00:01 UTC", "2006-01-02 15:04:05 MST"}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{"1970-01-01 00:00:01 UTC", "%Y-%m-%d %H:%M:%S %Z"}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{[]byte("Thu, 01 Jan 1970 00:00:01 UTC"), ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{time.Unix(1, 0).UTC(), ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
 
-		{"in": []interface{}{1, ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{1., ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{1.0, ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{1, ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{1., ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{1.0, ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
@@ -24,22 +24,22 @@ func TestGregorianToInternal(t *testing.T) {
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("GregorianToInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("GregorianToInternal(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("GregorianToInternal(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }
 
 func TestGregorianFromInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, ""}, "want": []interface{}{"Thu, 01 Jan 1970 00:00:01 UTC", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "2006-01-02 15:04:05 MST"}, "want": []interface{}{"1970-01-01 00:00:01 UTC", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "%Y-%m-%d %H:%M:%S %Z"}, "want": []interface{}{"1970-01-01 00:00:01 UTC", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "%Y-%m-%d %H:%M:%S %z"}, "want": []interface{}{"1970-01-01 00:00:01 +0000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, ""}, "want": []interface{}{"Thu, 01 Jan 1970 00:00:01 UTC", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "2006-01-02 15:04:05 MST"}, "want": []interface{}{"1970-01-01 00:00:01 UTC", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "%Y-%m-%d %H:%M:%S %Z"}, "want": []interface{}{"1970-01-01 00:00:01 UTC", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "%Y-%m-%d %H:%M:%S %z"}, "want": []interface{}{"1970-01-01 00:00:01 +0000", nil}},
 	}
 
 	for _, c := range cases {
-		out, err := FromInternal("gregorian", c["in"][0].(TAI64NAXURTime), c["in"][1].(string))
+		out, err := FromInternal("gregorian", c["in"][0].(TAI64NARUXTime), c["in"][1].(string))
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("GregorianFromInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
@@ -51,21 +51,21 @@ func TestGregorianFromInternal(t *testing.T) {
 
 func TestGregorianOffset(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{}, "in 1 second"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, []byte("in 1 second")}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, time.Second}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, "in 1 second"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, []byte("in 1 second")}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, time.Second}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{}, "in 17 bloxnards"}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{TAI64NAXURTime{}, TAI64NAXURTime{Seconds: 1}}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, "in 17 bloxnards"}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, TAI64NARUXTime{Seconds: 1}}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
-		out, err := Offset("gregorian", c["in"][0].(TAI64NAXURTime), c["in"][1])
+		out, err := Offset("gregorian", c["in"][0].(TAI64NARUXTime), c["in"][1])
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
-			t.Errorf("GregorianOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NAXURTime), c["in"][1], err, c["want"][1])
+			t.Errorf("GregorianOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NARUXTime), c["in"][1], err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("GregorianOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NAXURTime), c["in"][1], out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("GregorianOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NARUXTime), c["in"][1], out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }

--- a/calendars/jdc.go
+++ b/calendars/jdc.go
@@ -47,7 +47,7 @@ func init() {
 	)
 }
 
-func jdcToInternal(date interface{}, format string) (stamp TAI64NAXURTime, err error) {
+func jdcToInternal(date interface{}, format string) (stamp TAI64NARUXTime, err error) {
 	var jdc, mjd big.Float
 	var jdcP, mjdP *big.Float
 	var in string
@@ -102,12 +102,12 @@ func jdcToInternal(date interface{}, format string) (stamp TAI64NAXURTime, err e
 		jdc.Add(jdc.Add(jdc.Sub(&jdc, jdcP), jdcModifier), jdcBaseDay)
 	}
 
-	stamp = TAI64NAXURTimeFromFloat(*jdc.Mul(jdc.Sub(jdc.Sub(&jdc, jdcModifier), jdcBaseDay), big.NewFloat(86400)))
+	stamp = TAI64NARUXTimeFromFloat(*jdc.Mul(jdc.Sub(jdc.Sub(&jdc, jdcModifier), jdcBaseDay), big.NewFloat(86400)))
 
 	return
 }
 
-func jdcFromInternal(stamp TAI64NAXURTime, format string) (date string, err error) {
+func jdcFromInternal(stamp TAI64NARUXTime, format string) (date string, err error) {
 	var mjd, jdc big.Float
 	timestamp := stamp.Float()
 	mjd.Add(mjd.Quo(timestamp, big.NewFloat(86400)), jdcBaseDay)
@@ -135,7 +135,7 @@ func jdcFromInternal(stamp TAI64NAXURTime, format string) (date string, err erro
 	return
 }
 
-func jdcOffset(in TAI64NAXURTime, offset interface{}) (out TAI64NAXURTime, err error) {
+func jdcOffset(in TAI64NARUXTime, offset interface{}) (out TAI64NARUXTime, err error) {
 	var jdc float64
 	var mod string
 
@@ -164,7 +164,7 @@ func jdcOffset(in TAI64NAXURTime, offset interface{}) (out TAI64NAXURTime, err e
 		return
 	}
 
-	out = in.Add(TAI64NAXURTimeFromFloat(*big.NewFloat(jdc * 86400.)))
+	out = in.Add(TAI64NARUXTimeFromFloat(*big.NewFloat(jdc * 86400.)))
 
 	return
 }

--- a/calendars/jdc_test.go
+++ b/calendars/jdc_test.go
@@ -7,25 +7,25 @@ import (
 
 func TestJDCToInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{1, ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{1., ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{1.0, ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{"1", ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{"1.", ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{"1.0", ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{big.NewFloat(1), ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{*big.NewFloat(1), ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
-		{"in": []interface{}{[]byte("1"), ""}, "want": []interface{}{TAI64NAXURTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{1, ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{1., ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{1.0, ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{"1", ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{"1.", ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{"1.0", ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{big.NewFloat(1), ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{*big.NewFloat(1), ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
+		{"in": []interface{}{[]byte("1"), ""}, "want": []interface{}{TAI64NARUXTime{Seconds: -3506630400}, nil}},
 
-		{"in": []interface{}{"2440588.6", "full"}, "want": []interface{}{TAI64NAXURTime{Seconds: 95040}, nil}},
-		{"in": []interface{}{"2440588.6", "fullday"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"2440588.6", "fulltime"}, "want": []interface{}{TAI64NAXURTime{Seconds: 8640}, nil}},
-		{"in": []interface{}{"40588.1", "modified"}, "want": []interface{}{TAI64NAXURTime{Seconds: 95040}, nil}},
-		{"in": []interface{}{"40588.1", "day"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"40588.1", "time"}, "want": []interface{}{TAI64NAXURTime{Seconds: 8640}, nil}},
+		{"in": []interface{}{"2440588.6", "full"}, "want": []interface{}{TAI64NARUXTime{Seconds: 95040}, nil}},
+		{"in": []interface{}{"2440588.6", "fullday"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"2440588.6", "fulltime"}, "want": []interface{}{TAI64NARUXTime{Seconds: 8640}, nil}},
+		{"in": []interface{}{"40588.1", "modified"}, "want": []interface{}{TAI64NARUXTime{Seconds: 95040}, nil}},
+		{"in": []interface{}{"40588.1", "day"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"40588.1", "time"}, "want": []interface{}{TAI64NARUXTime{Seconds: 8640}, nil}},
 
-		{"in": []interface{}{"1.0", "invalid"}, "want": []interface{}{TAI64NAXURTime{}, ErrInvalidFormat}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{"1.0", "invalid"}, "want": []interface{}{TAI64NARUXTime{}, ErrInvalidFormat}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
@@ -33,27 +33,27 @@ func TestJDCToInternal(t *testing.T) {
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("JDCToInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("JDCToInternal(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("JDCToInternal(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }
 
 func TestJDCFromInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, ""}, "want": []interface{}{"40587.100000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "full"}, "want": []interface{}{"2440587.600000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "fullday"}, "want": []interface{}{"2440587", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "fulltime"}, "want": []interface{}{"0.600000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "modified"}, "want": []interface{}{"40587.100000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "day"}, "want": []interface{}{"40587", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "time"}, "want": []interface{}{"0.100000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, ""}, "want": []interface{}{"40587.100000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "full"}, "want": []interface{}{"2440587.600000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "fullday"}, "want": []interface{}{"2440587", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "fulltime"}, "want": []interface{}{"0.600000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "modified"}, "want": []interface{}{"40587.100000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "day"}, "want": []interface{}{"40587", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "time"}, "want": []interface{}{"0.100000", nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 8640}, "invalid"}, "want": []interface{}{"", ErrInvalidFormat}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 8640}, "invalid"}, "want": []interface{}{"", ErrInvalidFormat}},
 	}
 
 	for _, c := range cases {
-		out, err := FromInternal("jdc", c["in"][0].(TAI64NAXURTime), c["in"][1].(string))
+		out, err := FromInternal("jdc", c["in"][0].(TAI64NARUXTime), c["in"][1].(string))
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("JDCFromInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
@@ -65,23 +65,23 @@ func TestJDCFromInternal(t *testing.T) {
 
 func TestJDCOffset(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{}, 1}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, 1.0}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, "1"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, []byte("1")}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1.0}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, "1"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, []byte("1")}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{}, TAI64NAXURTime{Seconds: 1}}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, TAI64NARUXTime{Seconds: 1}}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
-		out, err := Offset("jdc", c["in"][0].(TAI64NAXURTime), c["in"][1])
+		out, err := Offset("jdc", c["in"][0].(TAI64NARUXTime), c["in"][1])
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
-			t.Errorf("JDCOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NAXURTime), c["in"][1], err, c["want"][1])
+			t.Errorf("JDCOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NARUXTime), c["in"][1], err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("JDCOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NAXURTime), c["in"][1], out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("JDCOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NARUXTime), c["in"][1], out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }

--- a/calendars/stardate.go
+++ b/calendars/stardate.go
@@ -202,7 +202,7 @@ func init() {
 	)
 }
 
-func stardateToInternal(date interface{}, format string) (stamp TAI64NAXURTime, err error) {
+func stardateToInternal(date interface{}, format string) (stamp TAI64NARUXTime, err error) {
 	var jdc big.Float
 	var in string
 
@@ -271,7 +271,7 @@ func stardateToInternal(date interface{}, format string) (stamp TAI64NAXURTime, 
 	return
 }
 
-func stardateFromInternal(stamp TAI64NAXURTime, format string) (date string, err error) {
+func stardateFromInternal(stamp TAI64NARUXTime, format string) (date string, err error) {
 	var jdcFloatP *big.Float
 	var jdcFloat big.Float
 	var jdcString string
@@ -322,9 +322,9 @@ func stardateFromInternal(stamp TAI64NAXURTime, format string) (date string, err
 	return
 }
 
-func stardateOffset(in TAI64NAXURTime, offset interface{}) (out TAI64NAXURTime, err error) {
+func stardateOffset(in TAI64NARUXTime, offset interface{}) (out TAI64NARUXTime, err error) {
 	var date, format, mod string
-	var adjust TAI64NAXURTime
+	var adjust TAI64NARUXTime
 
 	switch offset.(type) {
 	case []byte:

--- a/calendars/stardate_test.go
+++ b/calendars/stardate_test.go
@@ -7,55 +7,55 @@ import (
 
 func TestStardateToInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{-352996, "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 83289, Nano: 600000000}, nil}},
-		{"in": []interface{}{-352995.9024, "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-352996", "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 83289, Nano: 600000000}, nil}},
-		{"in": []interface{}{"-352995.9024", "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{big.NewFloat(-352995.9024), "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{*big.NewFloat(-352995.9024), "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{[]byte("-352995.9024"), "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{-352996, "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 83289, Nano: 600000000}, nil}},
+		{"in": []interface{}{-352995.9024, "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-352996", "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 83289, Nano: 600000000}, nil}},
+		{"in": []interface{}{"-352995.9024", "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{big.NewFloat(-352995.9024), "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{*big.NewFloat(-352995.9024), "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{[]byte("-352995.9024"), "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
 
-		{"in": []interface{}{"[-36]9355", ""}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"[-36]9355", "main"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-518956.8", "kennedy"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-353002.7397", "pugh90s"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-353004.3875", "pughfixed"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-352997.2603", "schmidt"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"23469.5414", "guide-equiv"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-320007.8084", "guide-tng"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-778176.1923", "guide-tos"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-352390.8245", "guide-oldtng"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-352995.9024", "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"-353230.64917", "red-dragon"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"47608.21918", "sto-hynes"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"47636.8359", "sto-academy"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"47608.48756", "sto-tom"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{"47608.1354", "sto-anthodev"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"[-36]9355", ""}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"[-36]9355", "main"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-518956.8", "kennedy"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-353002.7397", "pugh90s"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-353004.3875", "pughfixed"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-352997.2603", "schmidt"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"23469.5414", "guide-equiv"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-320007.8084", "guide-tng"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-778176.1923", "guide-tos"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-352390.8245", "guide-oldtng"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-352995.9024", "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"-353230.64917", "red-dragon"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"47608.21918", "sto-hynes"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"47636.8359", "sto-academy"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"47608.48756", "sto-tom"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{"47608.1354", "sto-anthodev"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
 
-		{"in": []interface{}{"[-27]4920", "main"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-436814.4", "kennedy"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-307855.1913", "pugh90s"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-307858.1901", "pughfixed"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-306144.8087", "schmidt"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"70322.38193", "guide-equiv"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-276985.1188", "guide-tng"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-654711.2454", "guide-tos"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-305536.9834", "guide-oldtng"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-306142.0613", "aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"-306345.6497", "red-dragon"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"94460.67071", "sto-hynes"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"94458.0039", "sto-academy"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"94461.3283", "sto-tom"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
-		{"in": []interface{}{"94460.62959", "sto-anthodev"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"[-27]4920", "main"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-436814.4", "kennedy"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-307855.1913", "pugh90s"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-307858.1901", "pughfixed"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-306144.8087", "schmidt"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"70322.38193", "guide-equiv"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-276985.1188", "guide-tng"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-654711.2454", "guide-tos"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-305536.9834", "guide-oldtng"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-306142.0613", "aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"-306345.6497", "red-dragon"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"94460.67071", "sto-hynes"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"94458.0039", "sto-academy"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"94461.3283", "sto-tom"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
+		{"in": []interface{}{"94460.62959", "sto-anthodev"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, nil}},
 
-		{"in": []interface{}{"[21]00000", "main"}, "want": []interface{}{TAI64NAXURTime{Seconds: 11139552000}, nil}},
-		{"in": []interface{}{"14814.24", "kennedy"}, "want": []interface{}{TAI64NAXURTime{Seconds: 11139552000}, nil}},
+		{"in": []interface{}{"[21]00000", "main"}, "want": []interface{}{TAI64NARUXTime{Seconds: 11139552000}, nil}},
+		{"in": []interface{}{"14814.24", "kennedy"}, "want": []interface{}{TAI64NARUXTime{Seconds: 11139552000}, nil}},
 
-		{"in": []interface{}{"[20]5005.82", "main"}, "want": []interface{}{TAI64NAXURTime{Seconds: 11139520896}, nil}},
+		{"in": []interface{}{"[20]5005.82", "main"}, "want": []interface{}{TAI64NARUXTime{Seconds: 11139520896}, nil}},
 
-		{"in": []interface{}{"1.0", "invalid"}, "want": []interface{}{TAI64NAXURTime{}, ErrInvalidFormat}},
-		{"in": []interface{}{"1512.90", "guide-oldtos"}, "want": []interface{}{TAI64NAXURTime{}, ErrInvalidFormat}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{"1.0", "invalid"}, "want": []interface{}{TAI64NARUXTime{}, ErrInvalidFormat}},
+		{"in": []interface{}{"1512.90", "guide-oldtos"}, "want": []interface{}{TAI64NARUXTime{}, ErrInvalidFormat}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
@@ -63,58 +63,58 @@ func TestStardateToInternal(t *testing.T) {
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("stardateToInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("stardateToInternal(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("stardateToInternal(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }
 
 func TestStardateFromInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, ""}, "want": []interface{}{"[-36]9355", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "main"}, "want": []interface{}{"[-36]9355", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "kennedy"}, "want": []interface{}{"-518956.8", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "pugh90s"}, "want": []interface{}{"-353002.7397", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "pughfixed"}, "want": []interface{}{"-353004.3875", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "schmidt"}, "want": []interface{}{"-352997.2603", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "guide-equiv"}, "want": []interface{}{"23469.54141", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "guide-tng"}, "want": []interface{}{"-320007.8084", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "guide-tos"}, "want": []interface{}{"-778176.1923", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "guide-oldtng"}, "want": []interface{}{"-352390.8245", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "aldrich"}, "want": []interface{}{"-352995.9024", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "red-dragon"}, "want": []interface{}{"-353230.6492", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "sto-hynes"}, "want": []interface{}{"47608.21918", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "sto-academy"}, "want": []interface{}{"47636.8359", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "sto-tom"}, "want": []interface{}{"47608.48756", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "sto-anthodev"}, "want": []interface{}{"47608.13541", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, ""}, "want": []interface{}{"[-36]9355", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "main"}, "want": []interface{}{"[-36]9355", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "kennedy"}, "want": []interface{}{"-518956.8", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "pugh90s"}, "want": []interface{}{"-353002.7397", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "pughfixed"}, "want": []interface{}{"-353004.3875", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "schmidt"}, "want": []interface{}{"-352997.2603", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "guide-equiv"}, "want": []interface{}{"23469.54141", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "guide-tng"}, "want": []interface{}{"-320007.8084", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "guide-tos"}, "want": []interface{}{"-778176.1923", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "guide-oldtng"}, "want": []interface{}{"-352390.8245", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "aldrich"}, "want": []interface{}{"-352995.9024", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "red-dragon"}, "want": []interface{}{"-353230.6492", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "sto-hynes"}, "want": []interface{}{"47608.21918", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "sto-academy"}, "want": []interface{}{"47636.8359", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "sto-tom"}, "want": []interface{}{"47608.48756", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "sto-anthodev"}, "want": []interface{}{"47608.13541", nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "main"}, "want": []interface{}{"[-27]4920", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "kennedy"}, "want": []interface{}{"-436814.4", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "pugh90s"}, "want": []interface{}{"-307855.1913", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "pughfixed"}, "want": []interface{}{"-307858.1901", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "schmidt"}, "want": []interface{}{"-306144.8087", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "guide-equiv"}, "want": []interface{}{"70322.38193", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "guide-tng"}, "want": []interface{}{"-276985.1188", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "guide-tos"}, "want": []interface{}{"-654711.2454", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "guide-oldtng"}, "want": []interface{}{"-305536.9834", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "aldrich"}, "want": []interface{}{"-306142.0613", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "red-dragon"}, "want": []interface{}{"-306345.6497", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "sto-hynes"}, "want": []interface{}{"94460.67071", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "sto-academy"}, "want": []interface{}{"94458.0039", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "sto-tom"}, "want": []interface{}{"94461.3283", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1478649600}, "sto-anthodev"}, "want": []interface{}{"94460.62959", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "main"}, "want": []interface{}{"[-27]4920", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "kennedy"}, "want": []interface{}{"-436814.4", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "pugh90s"}, "want": []interface{}{"-307855.1913", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "pughfixed"}, "want": []interface{}{"-307858.1901", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "schmidt"}, "want": []interface{}{"-306144.8087", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "guide-equiv"}, "want": []interface{}{"70322.38193", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "guide-tng"}, "want": []interface{}{"-276985.1188", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "guide-tos"}, "want": []interface{}{"-654711.2454", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "guide-oldtng"}, "want": []interface{}{"-305536.9834", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "aldrich"}, "want": []interface{}{"-306142.0613", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "red-dragon"}, "want": []interface{}{"-306345.6497", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "sto-hynes"}, "want": []interface{}{"94460.67071", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "sto-academy"}, "want": []interface{}{"94458.0039", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "sto-tom"}, "want": []interface{}{"94461.3283", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1478649600}, "sto-anthodev"}, "want": []interface{}{"94460.62959", nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 11139552000}, "main"}, "want": []interface{}{"[21]00000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 11139552000}, "kennedy"}, "want": []interface{}{"14814.24", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 11139552000}, "main"}, "want": []interface{}{"[21]00000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 11139552000}, "kennedy"}, "want": []interface{}{"14814.24", nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 11139520896}, "main"}, "want": []interface{}{"[20]5005.82", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 11139520896}, "main"}, "want": []interface{}{"[20]5005.82", nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "invalid"}, "want": []interface{}{"", ErrInvalidFormat}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 86400}, "guide-oldtos"}, "want": []interface{}{"", ErrInvalidFormat}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "invalid"}, "want": []interface{}{"", ErrInvalidFormat}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 86400}, "guide-oldtos"}, "want": []interface{}{"", ErrInvalidFormat}},
 	}
 
 	for _, c := range cases {
-		out, err := FromInternal("stardate", c["in"][0].(TAI64NAXURTime), c["in"][1].(string))
+		out, err := FromInternal("stardate", c["in"][0].(TAI64NARUXTime), c["in"][1].(string))
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("stardateFromInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
@@ -126,25 +126,25 @@ func TestStardateFromInternal(t *testing.T) {
 
 func TestStardateOffset(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{}, "-352995.9024 aldrich"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, []byte("-352995.9024 aldrich")}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, "-352995.9024 aldrich"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, []byte("-352995.9024 aldrich")}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{}, "aldrich -352995.9024"}, "want": []interface{}{TAI64NAXURTime{Seconds: 86400}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, "aldrich -352995.9024"}, "want": []interface{}{TAI64NARUXTime{Seconds: 86400}, nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{}, 1}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{TAI64NAXURTime{}, 1.0}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{TAI64NAXURTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{TAI64NAXURTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
-		{"in": []interface{}{TAI64NAXURTime{}, TAI64NAXURTime{Seconds: 1}}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1.0}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, TAI64NARUXTime{Seconds: 1}}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
-		out, err := Offset("stardate", c["in"][0].(TAI64NAXURTime), c["in"][1])
+		out, err := Offset("stardate", c["in"][0].(TAI64NARUXTime), c["in"][1])
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
-			t.Errorf("stardateOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NAXURTime), c["in"][1], err, c["want"][1])
+			t.Errorf("stardateOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NARUXTime), c["in"][1], err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("stardateOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NAXURTime), c["in"][1], out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("stardateOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NARUXTime), c["in"][1], out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }

--- a/calendars/tai64.go
+++ b/calendars/tai64.go
@@ -11,7 +11,7 @@ elsewhere.
 Supported Input Types:
   - string
   - []byte
-  - TAI64NAXURTime
+  - TAI64NARUXTime
   - math/big.Float for Offset
 
 Supported Format Strings:
@@ -19,9 +19,9 @@ Supported Format Strings:
   - tai64       - hexadecimal; just seconds
   - tai64n      - hexadecimal; with nanoseconds
   - tai64na     - hexadecimal; with attoseconds
-  - tai64nax    - hexadecimal; with xictoseconds
-  - tai64naxu   - hexadecimal; with uctoseconds
-  - tai64naxur  - hexadecimal; with roctoseconds
+  - tai64nar    - hexadecimal; with rontoseconds
+  - tai64naru   - hexadecimal; with udectoseconds
+  - tai64narux  - hexadecimal; with xindectoseconds
 
 */
 package calendars
@@ -39,7 +39,7 @@ func init() {
 		// name
 		"TAI64",
 		// toInternal
-		func(date interface{}, format string) (stamp TAI64NAXURTime, err error) {
+		func(date interface{}, format string) (stamp TAI64NARUXTime, err error) {
 			var dateString string
 			switch date.(type) {
 			// TODO - other types
@@ -47,8 +47,8 @@ func init() {
 				dateString = string(date.([]byte))
 			case string:
 				dateString = date.(string)
-			case TAI64NAXURTime:
-				stamp = date.(TAI64NAXURTime)
+			case TAI64NARUXTime:
+				stamp = date.(TAI64NARUXTime)
 				return
 			default:
 				err = errors.Wrap(ErrUnsupportedInput, 1)
@@ -61,13 +61,13 @@ func init() {
 				if len(tmp) < 2 {
 					tmp = append(tmp, "0")
 				}
-				_, err = fmt.Sscanf(fmt.Sprintf("%s %-045s", tmp[0], tmp[1]), "%d %09d%09d%09d%09d%09d", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Xicto, &stamp.Ucto, &stamp.Rocto)
-			case "tai64naxur":
-				_, err = fmt.Sscanf(dateString, "%016X%08X%08X%08X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Xicto, &stamp.Ucto, &stamp.Rocto)
-			case "tai64naxu":
-				_, err = fmt.Sscanf(dateString, "%016X%08X%08X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Xicto, &stamp.Ucto)
-			case "tai64nax":
-				_, err = fmt.Sscanf(dateString, "%016X%08X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Xicto)
+				_, err = fmt.Sscanf(fmt.Sprintf("%s %-045s", tmp[0], tmp[1]), "%d %09d%09d%09d%09d%09d", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Ronto, &stamp.Udecto, &stamp.Xindecto)
+			case "tai64narux":
+				_, err = fmt.Sscanf(dateString, "%016X%08X%08X%08X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Ronto, &stamp.Udecto, &stamp.Xindecto)
+			case "tai64naru":
+				_, err = fmt.Sscanf(dateString, "%016X%08X%08X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Ronto, &stamp.Udecto)
+			case "tai64nar":
+				_, err = fmt.Sscanf(dateString, "%016X%08X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto, &stamp.Ronto)
 			case "tai64na":
 				_, err = fmt.Sscanf(dateString, "%016X%08X%08X", &stamp.Seconds, &stamp.Nano, &stamp.Atto)
 			case "tai64n":
@@ -89,16 +89,16 @@ func init() {
 			return
 		},
 		// fromInternal
-		func(stamp TAI64NAXURTime, format string) (date string, err error) {
+		func(stamp TAI64NARUXTime, format string) (date string, err error) {
 			switch format {
 			case "decimal":
-				date = strings.TrimRight(strings.TrimRight(fmt.Sprintf("%0d.%09d%09d%09d%09d%09d", stamp.Seconds, stamp.Nano, stamp.Atto, stamp.Xicto, stamp.Ucto, stamp.Rocto), "0"), ".")
-			case "tai64naxur":
-				date = fmt.Sprintf("%016X%08X%08X%08X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto, stamp.Xicto, stamp.Ucto, stamp.Rocto)
-			case "tai64naxu":
-				date = fmt.Sprintf("%016X%08X%08X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto, stamp.Xicto, stamp.Ucto)
-			case "tai64nax":
-				date = fmt.Sprintf("%016X%08X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto, stamp.Xicto)
+				date = strings.TrimRight(strings.TrimRight(fmt.Sprintf("%0d.%09d%09d%09d%09d%09d", stamp.Seconds, stamp.Nano, stamp.Atto, stamp.Ronto, stamp.Udecto, stamp.Xindecto), "0"), ".")
+			case "tai64narux":
+				date = fmt.Sprintf("%016X%08X%08X%08X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto, stamp.Ronto, stamp.Udecto, stamp.Xindecto)
+			case "tai64naru":
+				date = fmt.Sprintf("%016X%08X%08X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto, stamp.Ronto, stamp.Udecto)
+			case "tai64nar":
+				date = fmt.Sprintf("%016X%08X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto, stamp.Ronto)
 			case "tai64na":
 				date = fmt.Sprintf("%016X%08X%08X", stamp.Seconds+0x4000000000000000, stamp.Nano, stamp.Atto)
 			case "tai64n":
@@ -112,20 +112,20 @@ func init() {
 			return
 		},
 		// offset
-		func(in TAI64NAXURTime, offset interface{}) (out TAI64NAXURTime, err error) {
-			var adjust TAI64NAXURTime
+		func(in TAI64NARUXTime, offset interface{}) (out TAI64NARUXTime, err error) {
+			var adjust TAI64NARUXTime
 			switch offset.(type) {
 			// TODO - other types
 			case big.Float:
-				adjust = TAI64NAXURTimeFromFloat(offset.(big.Float))
+				adjust = TAI64NARUXTimeFromFloat(offset.(big.Float))
 			case *big.Float:
-				adjust = TAI64NAXURTimeFromFloat(*offset.(*big.Float))
+				adjust = TAI64NARUXTimeFromFloat(*offset.(*big.Float))
 			case []byte:
-				adjust = TAI64NAXURTimeFromDecimalString(string(offset.([]byte)))
+				adjust = TAI64NARUXTimeFromDecimalString(string(offset.([]byte)))
 			case string:
-				adjust = TAI64NAXURTimeFromDecimalString(offset.(string))
-			case TAI64NAXURTime:
-				adjust = offset.(TAI64NAXURTime)
+				adjust = TAI64NARUXTimeFromDecimalString(offset.(string))
+			case TAI64NARUXTime:
+				adjust = offset.(TAI64NARUXTime)
 			default:
 				err = errors.Wrap(ErrUnsupportedInput, 1)
 			}
@@ -135,6 +135,6 @@ func init() {
 			return
 		},
 		// defaultFormat
-		"tai64naxur",
+		"tai64narux",
 	)
 }

--- a/calendars/tai64_test.go
+++ b/calendars/tai64_test.go
@@ -7,20 +7,20 @@ import (
 
 func TestTai64ToInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{"1", "decimal"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"1.", "decimal"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"1.0", "decimal"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"40000000000000010000000000000000000000000000000000000000", "tai64naxur"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"400000000000000100000000000000000000000000000000", "tai64naxu"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"4000000000000001000000000000000000000000", "tai64nax"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"40000000000000010000000000000000", "tai64na"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"400000000000000100000000", "tai64n"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"4000000000000001", "tai64"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{"4000000000000001", "invalid"}, "want": []interface{}{TAI64NAXURTime{}, ErrInvalidFormat}},
+		{"in": []interface{}{"1", "decimal"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"1.", "decimal"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"1.0", "decimal"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"40000000000000010000000000000000000000000000000000000000", "tai64narux"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"400000000000000100000000000000000000000000000000", "tai64naru"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"4000000000000001000000000000000000000000", "tai64nar"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"40000000000000010000000000000000", "tai64na"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"400000000000000100000000", "tai64n"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"4000000000000001", "tai64"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{"4000000000000001", "invalid"}, "want": []interface{}{TAI64NARUXTime{}, ErrInvalidFormat}},
 
-		{"in": []interface{}{[]byte("40000000000000010000000000000000000000000000000000000000"), "tai64naxur"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64naxur"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{1, "tai64naxur"}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{[]byte("40000000000000010000000000000000000000000000000000000000"), "tai64narux"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64narux"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{1, "tai64narux"}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
@@ -28,26 +28,26 @@ func TestTai64ToInternal(t *testing.T) {
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("Tai64ToInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("Tai64ToInternal(%#v, %#v)\nreturned %#v\nwanted   %#v", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("Tai64ToInternal(%#v, %#v)\nreturned %#v\nwanted   %#v", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }
 
 func TestTai64FromInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "decimal"}, "want": []interface{}{"1", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64naxur"}, "want": []interface{}{"40000000000000010000000000000000000000000000000000000000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64naxu"}, "want": []interface{}{"400000000000000100000000000000000000000000000000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64nax"}, "want": []interface{}{"4000000000000001000000000000000000000000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64na"}, "want": []interface{}{"40000000000000010000000000000000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64n"}, "want": []interface{}{"400000000000000100000000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "tai64"}, "want": []interface{}{"4000000000000001", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "invalid"}, "want": []interface{}{"", ErrInvalidFormat}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "decimal"}, "want": []interface{}{"1", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64narux"}, "want": []interface{}{"40000000000000010000000000000000000000000000000000000000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64naru"}, "want": []interface{}{"400000000000000100000000000000000000000000000000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64nar"}, "want": []interface{}{"4000000000000001000000000000000000000000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64na"}, "want": []interface{}{"40000000000000010000000000000000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64n"}, "want": []interface{}{"400000000000000100000000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "tai64"}, "want": []interface{}{"4000000000000001", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "invalid"}, "want": []interface{}{"", ErrInvalidFormat}},
 	}
 
 	for _, c := range cases {
-		out, err := FromInternal("tai64", c["in"][0].(TAI64NAXURTime), c["in"][1].(string))
+		out, err := FromInternal("tai64", c["in"][0].(TAI64NARUXTime), c["in"][1].(string))
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("Tai64FromInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
@@ -59,21 +59,21 @@ func TestTai64FromInternal(t *testing.T) {
 
 func TestTai64Offset(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{}, "1"}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, []byte("1")}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, TAI64NAXURTime{Seconds: 1}}, "want": []interface{}{TAI64NAXURTime{Seconds: 1}, nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, 1}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, "1"}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, []byte("1")}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, TAI64NARUXTime{Seconds: 1}}, "want": []interface{}{TAI64NARUXTime{Seconds: 1}, nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
-		out, err := Offset("tai64", c["in"][0].(TAI64NAXURTime), c["in"][1])
+		out, err := Offset("tai64", c["in"][0].(TAI64NARUXTime), c["in"][1])
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
-			t.Errorf("Tai64Offset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NAXURTime), c["in"][1], err, c["want"][1])
+			t.Errorf("Tai64Offset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NARUXTime), c["in"][1], err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("Tai64Offset(%#v, %#v)\nreturned %#v\nwanted   %#v", c["in"][0].(TAI64NAXURTime), c["in"][1], out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("Tai64Offset(%#v, %#v)\nreturned %#v\nwanted   %#v", c["in"][0].(TAI64NARUXTime), c["in"][1], out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }

--- a/calendars/unix.go
+++ b/calendars/unix.go
@@ -29,8 +29,8 @@ func init() {
 		// name
 		"unix",
 		// toInternal
-		func(date interface{}, format string) (stamp TAI64NAXURTime, err error) {
-			var tmp TAI64NAXURTime
+		func(date interface{}, format string) (stamp TAI64NARUXTime, err error) {
+			var tmp TAI64NARUXTime
 			// parse the value
 			tmp, err = unixParseDate(date)
 			if err != nil {
@@ -41,7 +41,7 @@ func init() {
 			return
 		},
 		// fromInternal
-		func(stamp TAI64NAXURTime, format string) (date string, err error) {
+		func(stamp TAI64NARUXTime, format string) (date string, err error) {
 			stamp = TAItoUTC(stamp)
 
 			// format the value
@@ -49,8 +49,8 @@ func init() {
 			return
 		},
 		// offset
-		func(in TAI64NAXURTime, offset interface{}) (out TAI64NAXURTime, err error) {
-			var tmp1, tmp2 TAI64NAXURTime
+		func(in TAI64NARUXTime, offset interface{}) (out TAI64NARUXTime, err error) {
+			var tmp1, tmp2 TAI64NARUXTime
 
 			tmp1 = TAItoUTC(in)
 
@@ -68,21 +68,21 @@ func init() {
 	)
 }
 
-func unixParseDate(date interface{}) (stamp TAI64NAXURTime, err error) {
+func unixParseDate(date interface{}) (stamp TAI64NARUXTime, err error) {
 	switch date.(type) {
 	// TODO - other types
 	case int:
-		stamp = TAI64NAXURTimeFromDecimalString(fmt.Sprintf("%d", date.(int)))
+		stamp = TAI64NARUXTimeFromDecimalString(fmt.Sprintf("%d", date.(int)))
 	case float64:
-		stamp = TAI64NAXURTimeFromDecimalString(fmt.Sprintf("%f", date.(float64)))
+		stamp = TAI64NARUXTimeFromDecimalString(fmt.Sprintf("%f", date.(float64)))
 	case big.Float:
-		stamp = TAI64NAXURTimeFromFloat(date.(big.Float))
+		stamp = TAI64NARUXTimeFromFloat(date.(big.Float))
 	case *big.Float:
-		stamp = TAI64NAXURTimeFromFloat(*date.(*big.Float))
+		stamp = TAI64NARUXTimeFromFloat(*date.(*big.Float))
 	case []byte:
-		stamp = TAI64NAXURTimeFromDecimalString(string(date.([]byte)))
+		stamp = TAI64NARUXTimeFromDecimalString(string(date.([]byte)))
 	case string:
-		stamp = TAI64NAXURTimeFromDecimalString(date.(string))
+		stamp = TAI64NARUXTimeFromDecimalString(date.(string))
 	default:
 		err = errors.Wrap(ErrUnsupportedInput, 1)
 	}

--- a/calendars/unix_test.go
+++ b/calendars/unix_test.go
@@ -7,17 +7,17 @@ import (
 
 func TestUnixToInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{1, ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{1., ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{1.0, ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{"1", ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{"1.", ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{"1.0", ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{big.NewFloat(1), ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{*big.NewFloat(1), ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
-		{"in": []interface{}{[]byte("1"), ""}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{1, ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{1., ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{1.0, ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{"1", ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{"1.", ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{"1.0", ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{big.NewFloat(1), ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{*big.NewFloat(1), ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
+		{"in": []interface{}{[]byte("1"), ""}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("-6.997489999999999987778664944926276803016662598"), nil}},
 
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, ""}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
@@ -25,22 +25,22 @@ func TestUnixToInternal(t *testing.T) {
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("UnixToInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("UnixToInternal(%#v, %#v)\nreturned %#v\nwanted   %#v", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("UnixToInternal(%#v, %#v)\nreturned %#v\nwanted   %#v", c["in"][0], c["in"][1].(string), out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }
 
 func TestUnixFromInternal(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, ""}, "want": []interface{}{"9.000082000", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "%f"}, "want": []interface{}{"9.000082", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "%.45f"}, "want": []interface{}{"9.000081999999999027295416453853249549865722656", nil}},
-		{"in": []interface{}{TAI64NAXURTime{Seconds: 1}, "%.0f"}, "want": []interface{}{"9", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, ""}, "want": []interface{}{"9.000082000", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "%f"}, "want": []interface{}{"9.000082", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "%.45f"}, "want": []interface{}{"9.000081999999999027295416453853249549865722656", nil}},
+		{"in": []interface{}{TAI64NARUXTime{Seconds: 1}, "%.0f"}, "want": []interface{}{"9", nil}},
 	}
 
 	for _, c := range cases {
-		out, err := FromInternal("unix", c["in"][0].(TAI64NAXURTime), c["in"][1].(string))
+		out, err := FromInternal("unix", c["in"][0].(TAI64NARUXTime), c["in"][1].(string))
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
 			t.Errorf("UnixFromInternal(%#v, %#v) gave error %#v; want %#v", c["in"][0], c["in"][1].(string), err, c["want"][1])
 		}
@@ -52,22 +52,22 @@ func TestUnixFromInternal(t *testing.T) {
 
 func TestUnixOffset(t *testing.T) {
 	cases := []map[string][]interface{}{
-		{"in": []interface{}{TAI64NAXURTime{}, 1}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("1"), nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, 1.0}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("1"), nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, "1"}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("1"), nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, []byte("1")}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("1"), nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("1"), nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NAXURTimeFromDecimalString("1"), nil}},
-		{"in": []interface{}{TAI64NAXURTime{}, TAI64NAXURTime{Seconds: 1}}, "want": []interface{}{TAI64NAXURTime{}, ErrUnsupportedInput}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("1"), nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, 1.0}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("1"), nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, "1"}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("1"), nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, []byte("1")}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("1"), nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("1"), nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, *big.NewFloat(1)}, "want": []interface{}{TAI64NARUXTimeFromDecimalString("1"), nil}},
+		{"in": []interface{}{TAI64NARUXTime{}, TAI64NARUXTime{Seconds: 1}}, "want": []interface{}{TAI64NARUXTime{}, ErrUnsupportedInput}},
 	}
 
 	for _, c := range cases {
-		out, err := Offset("unix", c["in"][0].(TAI64NAXURTime), c["in"][1])
+		out, err := Offset("unix", c["in"][0].(TAI64NARUXTime), c["in"][1])
 		if (err != nil && c["want"][1] != nil && err.Error() != c["want"][1].(error).Error()) || (err == nil && err != c["want"][1]) || (c["want"][1] == nil && err != c["want"][1]) {
-			t.Errorf("UnixOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NAXURTime), c["in"][1], err, c["want"][1])
+			t.Errorf("UnixOffset(%#v, %#v) gave error %#v; want %#v", c["in"][0].(TAI64NARUXTime), c["in"][1], err, c["want"][1])
 		}
-		if out != c["want"][0].(TAI64NAXURTime) {
-			t.Errorf("UnixOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NAXURTime), c["in"][1], out, c["want"][0].(TAI64NAXURTime))
+		if out != c["want"][0].(TAI64NARUXTime) {
+			t.Errorf("UnixOffset(%#v, %#v)\nreturned %s\nwanted   %s", c["in"][0].(TAI64NARUXTime), c["in"][1], out, c["want"][0].(TAI64NARUXTime))
 		}
 	}
 }

--- a/calends.go
+++ b/calends.go
@@ -41,7 +41,7 @@ type Calends struct {
 }
 
 // Version of the library
-var Version = "0.0.6"
+var Version = "0.1.0"
 
 // Create is the mechanism for constructing new Calends objects.
 /*

--- a/calends.go
+++ b/calends.go
@@ -2,9 +2,9 @@
 // calendar systems.
 /*
 
-Dates and times are converted to "TAI64NAXUR instants", values that
+Dates and times are converted to "TAI64NARUX instants", values that
 unambiguously encode moments over 146 billion years into the past or future, in
-increments as small as 10**-45 seconds (internally called a "roctosecond", but
+increments as small as 10**-45 seconds (internally called a "xindectosecond", but
 there's no actual prefix for units this small, even though the Planck Time - the
 smallest meaningful period of time in quantum physics - is 54 of them).
 Calculations and comparisons are done using these instants, to maintain the
@@ -35,9 +35,9 @@ import (
 // The Calends type is the core of the library, and the primary interface with
 // it.
 type Calends struct {
-	startTime calendars.TAI64NAXURTime
+	startTime calendars.TAI64NARUXTime
 	duration  *big.Float
-	endTime   calendars.TAI64NAXURTime
+	endTime   calendars.TAI64NARUXTime
 }
 
 // Version of the library
@@ -89,7 +89,7 @@ func Create(stamp interface{}, calendar, format string) (instance Calends, err e
 
 	switch stamp := stamp.(type) {
 	default:
-		var internal calendars.TAI64NAXURTime
+		var internal calendars.TAI64NARUXTime
 
 		internal, err = calendars.ToInternal(calendar, stamp, format)
 		instance = Calends{
@@ -131,16 +131,16 @@ func retrieveInstance(calendar string, stamp map[string]interface{}, format stri
 		instance = Calends{
 			startTime: start,
 			duration:  &duration,
-			endTime:   start.Add(calendars.TAI64NAXURTimeFromFloat(duration)),
+			endTime:   start.Add(calendars.TAI64NARUXTimeFromFloat(duration)),
 		}
 	} else if hasEnd && hasDuration {
 		instance = Calends{
-			startTime: end.Sub(calendars.TAI64NAXURTimeFromFloat(duration)),
+			startTime: end.Sub(calendars.TAI64NARUXTimeFromFloat(duration)),
 			duration:  &duration,
 			endTime:   end,
 		}
 	} else {
-		var internal calendars.TAI64NAXURTime
+		var internal calendars.TAI64NARUXTime
 
 		internal, err = calendars.ToInternal(calendar, stamp, format)
 		instance = Calends{
@@ -153,7 +153,7 @@ func retrieveInstance(calendar string, stamp map[string]interface{}, format stri
 	return
 }
 
-func retrieveStart(calendar string, stamp map[string]interface{}, format string) (start calendars.TAI64NAXURTime, hasStart bool, err error) {
+func retrieveStart(calendar string, stamp map[string]interface{}, format string) (start calendars.TAI64NARUXTime, hasStart bool, err error) {
 	var rawStart interface{}
 	rawStart, hasStart = stamp["start"]
 	if hasStart {
@@ -163,7 +163,7 @@ func retrieveStart(calendar string, stamp map[string]interface{}, format string)
 	return
 }
 
-func retrieveEnd(calendar string, stamp map[string]interface{}, format string) (end calendars.TAI64NAXURTime, hasEnd bool, err error) {
+func retrieveEnd(calendar string, stamp map[string]interface{}, format string) (end calendars.TAI64NARUXTime, hasEnd bool, err error) {
 	var rawEnd interface{}
 	rawEnd, hasEnd = stamp["end"]
 	if hasEnd {
@@ -285,7 +285,7 @@ func (c Calends) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (c *Calends) UnmarshalText(text []byte) error {
-	var startTime, endTime calendars.TAI64NAXURTime
+	var startTime, endTime calendars.TAI64NARUXTime
 	var start, end string
 
 	n, err := fmt.Sscanf(string(text), "%56s::%56s", &start, &end)
@@ -303,7 +303,7 @@ func (c *Calends) UnmarshalText(text []byte) error {
 	tmp, err := Create(map[string]interface{}{
 		"start": startTime,
 		"end":   endTime,
-	}, "tai64", "tai64naxur")
+	}, "tai64", "tai64narux")
 
 	*c = tmp
 
@@ -331,7 +331,7 @@ func (c Calends) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the encoding/json.Unmarshaler interface.
 func (c *Calends) UnmarshalJSON(text []byte) error {
-	var startTime, endTime calendars.TAI64NAXURTime
+	var startTime, endTime calendars.TAI64NARUXTime
 
 	parsed := make(map[string]string)
 	err := json.Unmarshal(text, &parsed)

--- a/comparisons.go
+++ b/comparisons.go
@@ -6,7 +6,7 @@ import (
 	"github.com/danhunsaker/calends/calendars"
 )
 
-func getTimesByMode(c, z Calends, mode string) (x, y calendars.TAI64NAXURTime) {
+func getTimesByMode(c, z Calends, mode string) (x, y calendars.TAI64NARUXTime) {
 	switch mode {
 	case "end":
 		x = c.endTime
@@ -96,7 +96,7 @@ func (c Calends) Overlaps(z Calends) bool {
 // Abuts checks whether the current object starts when another object ends, or
 // vice-versa, and that neither contains the other.
 func (c Calends) Abuts(z Calends) bool {
-	return (c.Compare(z, "start-end") == 0 && c.Compare(z, "end-start") == 0) && !(c.Contains(z) || z.Contains(c))
+	return ((c.Compare(z, "start-end") == 0 || c.Compare(z, "end-start") == 0) && !(c.Contains(z) || z.Contains(c)))
 }
 
 // IsBefore checks whether both of the current object's endpoints occur before

--- a/docs/c/custom_calendars.rst
+++ b/docs/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/go/custom_calendars.rst
+++ b/docs/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/go/usage.rst
+++ b/docs/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/php/custom_calendars.rst
+++ b/docs/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/systems.rst
+++ b/docs/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/systems/tai64.rst
+++ b/docs/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/ar-SA/c/custom_calendars.rst
+++ b/docs/translations/ar-SA/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/ar-SA/go/custom_calendars.rst
+++ b/docs/translations/ar-SA/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/ar-SA/go/usage.rst
+++ b/docs/translations/ar-SA/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/ar-SA/php/custom_calendars.rst
+++ b/docs/translations/ar-SA/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/ar-SA/systems.rst
+++ b/docs/translations/ar-SA/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/ar-SA/systems/tai64.rst
+++ b/docs/translations/ar-SA/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/de-DE/c/custom_calendars.rst
+++ b/docs/translations/de-DE/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/de-DE/go/custom_calendars.rst
+++ b/docs/translations/de-DE/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/de-DE/go/usage.rst
+++ b/docs/translations/de-DE/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/de-DE/php/custom_calendars.rst
+++ b/docs/translations/de-DE/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/de-DE/systems.rst
+++ b/docs/translations/de-DE/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/de-DE/systems/tai64.rst
+++ b/docs/translations/de-DE/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/eo-UY/c/custom_calendars.rst
+++ b/docs/translations/eo-UY/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/eo-UY/go/custom_calendars.rst
+++ b/docs/translations/eo-UY/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/eo-UY/go/usage.rst
+++ b/docs/translations/eo-UY/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/eo-UY/php/custom_calendars.rst
+++ b/docs/translations/eo-UY/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/eo-UY/systems.rst
+++ b/docs/translations/eo-UY/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/eo-UY/systems/tai64.rst
+++ b/docs/translations/eo-UY/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/es-ES/c/custom_calendars.rst
+++ b/docs/translations/es-ES/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/es-ES/go/custom_calendars.rst
+++ b/docs/translations/es-ES/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/es-ES/go/usage.rst
+++ b/docs/translations/es-ES/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/es-ES/php/custom_calendars.rst
+++ b/docs/translations/es-ES/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/es-ES/systems.rst
+++ b/docs/translations/es-ES/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/es-ES/systems/tai64.rst
+++ b/docs/translations/es-ES/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/fr-FR/c/custom_calendars.rst
+++ b/docs/translations/fr-FR/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/fr-FR/go/custom_calendars.rst
+++ b/docs/translations/fr-FR/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/fr-FR/go/usage.rst
+++ b/docs/translations/fr-FR/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/fr-FR/php/custom_calendars.rst
+++ b/docs/translations/fr-FR/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/fr-FR/systems.rst
+++ b/docs/translations/fr-FR/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/fr-FR/systems/tai64.rst
+++ b/docs/translations/fr-FR/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/it-IT/c/custom_calendars.rst
+++ b/docs/translations/it-IT/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/it-IT/go/custom_calendars.rst
+++ b/docs/translations/it-IT/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/it-IT/go/usage.rst
+++ b/docs/translations/it-IT/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/it-IT/php/custom_calendars.rst
+++ b/docs/translations/it-IT/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/it-IT/systems.rst
+++ b/docs/translations/it-IT/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/it-IT/systems/tai64.rst
+++ b/docs/translations/it-IT/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/ja-JP/c/custom_calendars.rst
+++ b/docs/translations/ja-JP/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/ja-JP/go/custom_calendars.rst
+++ b/docs/translations/ja-JP/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/ja-JP/go/usage.rst
+++ b/docs/translations/ja-JP/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/ja-JP/php/custom_calendars.rst
+++ b/docs/translations/ja-JP/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/ja-JP/systems.rst
+++ b/docs/translations/ja-JP/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/ja-JP/systems/tai64.rst
+++ b/docs/translations/ja-JP/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/jbo-EN/c/custom_calendars.rst
+++ b/docs/translations/jbo-EN/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/jbo-EN/go/custom_calendars.rst
+++ b/docs/translations/jbo-EN/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/jbo-EN/go/usage.rst
+++ b/docs/translations/jbo-EN/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/jbo-EN/php/custom_calendars.rst
+++ b/docs/translations/jbo-EN/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/jbo-EN/systems.rst
+++ b/docs/translations/jbo-EN/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/jbo-EN/systems/tai64.rst
+++ b/docs/translations/jbo-EN/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/ru-RU/c/custom_calendars.rst
+++ b/docs/translations/ru-RU/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/ru-RU/go/custom_calendars.rst
+++ b/docs/translations/ru-RU/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/ru-RU/go/usage.rst
+++ b/docs/translations/ru-RU/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/ru-RU/php/custom_calendars.rst
+++ b/docs/translations/ru-RU/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/ru-RU/systems.rst
+++ b/docs/translations/ru-RU/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/ru-RU/systems/tai64.rst
+++ b/docs/translations/ru-RU/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/tlh-AA/c/custom_calendars.rst
+++ b/docs/translations/tlh-AA/c/custom_calendars.rst
@@ -152,7 +152,7 @@ DeS entirely pong be'nI''a'wI', Datu' narghtaHvIS 'oH helpers.
 
 .. c:type:: TAI64Time
 
-   '' tai64naxur '' instant neH reliable, ngeD-bIDameH format ngevwI'. Hoch
+   '' tai64narux '' instant neH reliable, ngeD-bIDameH format ngevwI'. Hoch
    ngevwI' 9-digit fractional segment neH chev 32-bit integer choq
    jen qechmeyDaj Huj accuracy. ghaH Hutlh vay' wuv lo'laHghach
    SIrgh parse pagh external arbitrary-precision math be'nI''a'wI', Datu'.
@@ -169,17 +169,17 @@ DeS entirely pong be'nI''a'wI', Datu' narghtaHvIS 'oH helpers.
 
         attoseconds qaSchoH nob nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        xictoseconds qaSchoH nob attosecond
+        rontoseconds qaSchoH nob attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        uctoseconds qaSchoH nob xictosecond
+        udectoseconds qaSchoH nob rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        roctoseconds qaSchoH nob uctosecond
+        xindectoseconds qaSchoH nob udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/tlh-AA/go/custom_calendars.rst
+++ b/docs/translations/tlh-AA/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/tlh-AA/go/usage.rst
+++ b/docs/translations/tlh-AA/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/tlh-AA/php/custom_calendars.rst
+++ b/docs/translations/tlh-AA/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/tlh-AA/systems.rst
+++ b/docs/translations/tlh-AA/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/tlh-AA/systems/tai64.rst
+++ b/docs/translations/tlh-AA/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/docs/translations/zh-CN/c/custom_calendars.rst
+++ b/docs/translations/zh-CN/c/custom_calendars.rst
@@ -152,7 +152,7 @@ handled entirely by these helpers in the library itself.
 
 .. c:type:: TAI64Time
 
-   Stores a ``TAI64NAXUR`` instant in a reliable, easy-converted format. Each
+   Stores a ``TAI64NARUX`` instant in a reliable, easy-converted format. Each
    9-digit fractional segment is stored in a separate 32-bit integer to preserve
    its value with a very high degree of accuracy, without having to rely on
    string parsing or external arbitrary-precision math libraries.
@@ -169,17 +169,17 @@ handled entirely by these helpers in the library itself.
 
         Attoseconds since the given nanosecond
 
-   .. c:member:: unsigned int xicto
+   .. c:member:: unsigned int ronto
 
-        Xictoseconds since the given attosecond
+        Rontoseconds since the given attosecond
 
-   .. c:member:: unsigned int ucto
+   .. c:member:: unsigned int udecto
 
-        Uctoseconds since the given xictosecond
+        Udectoseconds since the given rontosecond
 
-   .. c:member:: unsigned int rocto
+   .. c:member:: unsigned int xindecto
 
-        Roctoseconds since the given uctosecond
+        Xindectoseconds since the given udectosecond
 
    .. c:member:: unsigned int padding
 

--- a/docs/translations/zh-CN/go/custom_calendars.rst
+++ b/docs/translations/zh-CN/go/custom_calendars.rst
@@ -21,7 +21,7 @@ The interface in question looks like this:
 
 .. go:type:: CalendarDefinition
 
-   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) ToInternal(date interface, format string) (TAI64NARUXTime, error)
 
       :param date: The input date. Should support :go:type:`string` at the very
                    minimum.
@@ -29,17 +29,17 @@ The interface in question looks like this:
       :param format: The format string for parsing the input date.
       :type format: :go:type:`string`
       :return: The parsed internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
       Converts an input date/time representation to an internal
-      :go:type:`TAI64NAXURTime`.
+      :go:type:`TAI64NARUXTime`.
 
-   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NAXURTime, format string) (string, error)
+   .. go:function:: func (CalendarDefinition) FromInternal(stamp TAI64NARUXTime, format string) (string, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param format: The format string for formatting the output date.
       :type format: :go:type:`string`
       :return: The formatted date/time.
@@ -47,21 +47,21 @@ The interface in question looks like this:
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Converts an internal :go:type:`TAI64NAXURTime` to a date/time string.
+      Converts an internal :go:type:`TAI64NARUXTime` to a date/time string.
 
-   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NAXURTime, offset interface) (TAI64NAXURTime, error)
+   .. go:function:: func (CalendarDefinition) Offset(stamp TAI64NARUXTime, offset interface) (TAI64NARUXTime, error)
 
       :param stamp: The internal timestamp value.
-      :type stamp: :go:type:`TAI64NAXURTime`
+      :type stamp: :go:type:`TAI64NARUXTime`
       :param offset: The input offset. Should support :go:type:`string` at the
                      very minimum.
       :type offset: :go:type:`interface{}`
       :return: The adjusted internal timestamp.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
       :return: Any error that occurs.
       :rtype: :go:type:`error`
 
-      Adds the given offset to an internal :go:type:`TAI64NAXURTime`.
+      Adds the given offset to an internal :go:type:`TAI64NARUXTime`.
 
 Registration
 ------------
@@ -138,7 +138,7 @@ Types and Values
 
 Now we get to the inner workings that make calendar systems function – even the
 built-in ones. The majority of the "magic" comes from the
-:go:type:`TAI64NAXURTime` object itself, as a reliable way of storing the exact
+:go:type:`TAI64NARUXTime` object itself, as a reliable way of storing the exact
 instants being calculated, and the only way times are handled by the library
 itself. A handful of methods provide basic operations that calendar system
 developers can use to simplify their conversions (adding and subtracting the
@@ -149,69 +149,69 @@ offsets. As long as you can convert your dates to/from Unix timestamps in a
 :go:type:`string` or :go:type:`math/big.Float`, the rest is handled entirely by
 these helpers in the library itself.
 
-.. go:type:: TAI64NAXURTime
+.. go:type:: TAI64NARUXTime
 
    :param int64 Seconds: The number of TAI seconds since ``CE 1970-01-01
                          00:00:00 TAI``.
    :param uint32 Nano: The first 9 digits of the timestamp's fractional
                        component.
    :param uint32 Atto: The 10th through 18th digits of the fractional component.
-   :param uint32 Xicto: The 19th through 27th digits of the fractional
+   :param uint32 Ronto: The 19th through 27th digits of the fractional
                         component.
-   :param uint32 Ucto: The 28th through 36th digits of the fractional component.
-   :param uint32 Rocto: The 37th through 45th digits of the fractional
+   :param uint32 Udecto: The 28th through 36th digits of the fractional component.
+   :param uint32 Xindecto: The 37th through 45th digits of the fractional
                         component.
 
-   :go:type:`TAI64NAXURTime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :go:type:`TAI64NARUXTime` stores a ``TAI64NARUX`` instant in a reliable,
    easy-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or Golang's
    :go:type:`math/big.*` values.
 
-   .. go:function:: func (TAI64NAXURTime) Add(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Add(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to add to the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The sum of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the sum of two :go:type:`TAI64NAXURTime` values.
+      Calculates the sum of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) Sub(z TAI64NAXURTime) TAI64NAXURTime
+   .. go:function:: func (TAI64NARUXTime) Sub(z TAI64NARUXTime) TAI64NARUXTime
 
       :param z: The timestamp to subtract from the current one.
-      :type z: :go:type:`TAI64NAXURTime`
+      :type z: :go:type:`TAI64NARUXTime`
       :return: The difference of the two timestamps.
-      :rtype: :go:type:`TAI64NAXURTime`
+      :rtype: :go:type:`TAI64NARUXTime`
 
-      Calculates the difference of two :go:type:`TAI64NAXURTime` values.
+      Calculates the difference of two :go:type:`TAI64NARUXTime` values.
 
-   .. go:function:: func (TAI64NAXURTime) String() string
+   .. go:function:: func (TAI64NARUXTime) String() string
 
       :return: The decimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
-      Returns the decimal string representation of the :go:type:`TAI64NAXURTime`
+      Returns the decimal string representation of the :go:type:`TAI64NARUXTime`
       value.
 
-   .. go:function:: func (TAI64NAXURTime) HexString() string
+   .. go:function:: func (TAI64NARUXTime) HexString() string
 
       :return: The hexadecimal string representation of the current timestamp.
       :rtype: :go:type:`string`
 
       Returns the hexadecimal string representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) Float() Float
+   .. go:function:: func (TAI64NARUXTime) Float() Float
 
       :return: The arbitrary-precision floating point representation of the
                current timestamp.
       :rtype: :go:type:`math/big.(*Float)`
 
       Returns the :go:type:`math/big.(*Float)` representation of the
-      :go:type:`TAI64NAXURTime` value.
+      :go:type:`TAI64NARUXTime` value.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalText() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalText() ([]byte, error)
 
       :return: A byte slice containing the marshalled text.
       :rtype: :go:type:`[]byte`
@@ -220,7 +220,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalText(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalText(in []byte) error
 
       :param in: A byte slice containing the marshalled text.
       :type in: :go:type:`[]byte`
@@ -229,7 +229,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.TextUnmarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) MarshalBinary() ([]byte, error)
+   .. go:function:: func (TAI64NARUXTime) MarshalBinary() ([]byte, error)
 
       :return: A byte slice containing the marshalled binary data.
       :rtype: :go:type:`[]byte`
@@ -238,7 +238,7 @@ these helpers in the library itself.
 
       Implements the :go:type:`encoding.BinaryMarshaler` interface.
 
-   .. go:function:: func (TAI64NAXURTime) UnmarshalBinary(in []byte) error
+   .. go:function:: func (TAI64NARUXTime) UnmarshalBinary(in []byte) error
 
       :param in: A byte slice containing the marshalled binary data.
       :type in: :go:type:`[]byte`
@@ -250,54 +250,54 @@ these helpers in the library itself.
 Helpers
 -------
 
-.. go:function:: func TAI64NAXURTimeFromDecimalString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromDecimalString(in string) TAI64NARUXTime
 
    :param in: The decimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its decimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its decimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromHexString(in string) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromHexString(in string) TAI64NARUXTime
 
    :param in: The hexadecimal string representation of a timestamp to calculate.
    :type in: :go:type:`string`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its hexadecimal string
+   Calculates a :go:type:`TAI64NARUXTime` from its hexadecimal string
    representation.
 
-.. go:function:: func TAI64NAXURTimeFromFloat(in Float) TAI64NAXURTime
+.. go:function:: func TAI64NARUXTimeFromFloat(in Float) TAI64NARUXTime
 
    :param in: The arbitrary-precision floating point representation of a
               timestamp to calculate.
    :type in: :go:type:`math/big.Float`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Calculates a :go:type:`TAI64NAXURTime` from its :go:type:`math/big.Float`
+   Calculates a :go:type:`TAI64NARUXTime` from its :go:type:`math/big.Float`
    representation.
 
-.. go:function:: func UTCtoTAI(utc TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func UTCtoTAI(utc TAI64NARUXTime) TAI64NARUXTime
 
    :param utc: The timestamp to remove the UTC offset from.
-   :type utc: :go:type:`TAI64NAXURTime`
+   :type utc: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Removes the UTC leap second offset from a TAI64NAXURTime value.
+   Removes the UTC leap second offset from a TAI64NARUXTime value.
 
-.. go:function:: func TAItoUTC(tai TAI64NAXURTime) TAI64NAXURTime
+.. go:function:: func TAItoUTC(tai TAI64NARUXTime) TAI64NARUXTime
 
    :param tai: The timestamp to add the UTC offset to.
-   :type tai: :go:type:`TAI64NAXURTime`
+   :type tai: :go:type:`TAI64NARUXTime`
    :return: The calculated timestamp.
-   :rtype: :go:type:`TAI64NAXURTime`
+   :rtype: :go:type:`TAI64NARUXTime`
 
-   Adds the UTC leap second offset to a TAI64NAXURTime value.
+   Adds the UTC leap second offset to a TAI64NARUXTime value.
 
 Errors
 ------

--- a/docs/translations/zh-CN/go/usage.rst
+++ b/docs/translations/zh-CN/go/usage.rst
@@ -12,7 +12,7 @@ Calends exposes a very small handful of things for use outside the library
 itself. One is the :go:type:`Calends` class, documented here, which should be
 the only interface users of the library ever need to touch.
 
-Another thing Calends exposes is the :go:type:`calendars.TAI64NAXURTime` class,
+Another thing Calends exposes is the :go:type:`calendars.TAI64NARUXTime` class,
 used to store and manipulate the instants of time which make up a
 :go:type:`Calends` instance. The rest are interfaces for extending the library's
 functionality. These are covered in the :ref:`Custom Calendars in Golang
@@ -63,7 +63,7 @@ Create
    the calendar system itself unchanged.
 
    The calendar system then converts ``value`` to a
-   :go:type:`calendars.TAI64NAXURTime` instant, which the :go:type:`Calends`
+   :go:type:`calendars.TAI64NARUXTime` instant, which the :go:type:`Calends`
    object sets to the appropriate internal value.
 
 Read

--- a/docs/translations/zh-CN/php/custom_calendars.rst
+++ b/docs/translations/zh-CN/php/custom_calendars.rst
@@ -171,7 +171,7 @@ helpers in the library itself.
 
 .. php:class:: TAITime
 
-   :php:class:`TAITime` stores a ``TAI64NAXUR`` instant in a reliable,
+   :php:class:`TAITime` stores a ``TAI64NARUX`` instant in a reliable,
    easily-converted format. Each 9-digit fractional segment is stored in a
    separate 32-bit integer to preserve its value with a very high degree of
    accuracy, without having to rely on string parsing or external
@@ -189,15 +189,15 @@ helpers in the library itself.
 
       The 10th through 18th digits of the fractional component.
 
-   .. php:attr:: xicto (integer)
+   .. php:attr:: ronto (integer)
 
       The 19th through 27th digits of the fractional component.
 
-   .. php:attr:: ucto (integer)
+   .. php:attr:: udecto (integer)
 
       The 28th through 36th digits of the fractional component.
 
-   .. php:attr:: rocto (integer)
+   .. php:attr:: xindecto (integer)
 
       The 37th through 45th digits of the fractional component.
 

--- a/docs/translations/zh-CN/systems.rst
+++ b/docs/translations/zh-CN/systems.rst
@@ -11,7 +11,7 @@ can also add custom systems to your apps without waiting for us to add them
 ourselves – instructions for that are in the Custom Calendars section, below.
 
 Throughout these documents, the term ``TAITime`` is used to refer generically to
-the ``TAI64NAXURTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
+the ``TAI64NARUXTime``, ``TAI64Time``, or ``TAITime`` type. The exact form of
 this name you'll see most often varies by programming language, and is covered
 in much more detail in the Custom Calendars section.
 

--- a/docs/translations/zh-CN/systems/tai64.rst
+++ b/docs/translations/zh-CN/systems/tai64.rst
@@ -27,11 +27,11 @@ a manner that allows them to be used elsewhere.
     Representation
   - ``tai64na``    - hexadecimal; with attoseconds; TAI64NA External
     Representation
-  - ``tai64nax``   - hexadecimal; with xictoseconds; TAI64NAX External
+  - ``tai64nar``   - hexadecimal; with rontoseconds; TAI64NAR External
     Representation
-  - ``tai64naxu``  - hexadecimal; with uctoseconds; TAI64NAXU External
+  - ``tai64naru``  - hexadecimal; with udectoseconds; TAI64NARU External
     Representation
-  - ``tai64naxur`` - **hexadecimal; with roctoseconds**; TAI64NAXUR External
+  - ``tai64narux`` - **hexadecimal; with xindectoseconds**; TAI64NARUX External
     Representation
 
 *Offsets:*

--- a/libcalends/calendars.go
+++ b/libcalends/calendars.go
@@ -2,13 +2,13 @@ package main
 
 /*
 typedef struct _TAI64Time {
-        long long int Seconds; // Seconds since 1970-01-01 00:00:00 TAI
-        unsigned int Nano;     // Nanoseconds since the given second
-        unsigned int Atto;     // Attoseconds since the given nanosecond
-        unsigned int Xicto;    // Xictoseconds since the given attosecond
-        unsigned int Ucto;     // Uctoseconds since the given xictosecond
-        unsigned int Rocto;    // Roctoseconds since the given uctosecond
-        unsigned int padding;  // round the value out to the nearest 64 bits
+    long long int Seconds; // Seconds since 1970-01-01 00:00:00 TAI
+    unsigned int Nano;     // Billionths of a second since the given second
+    unsigned int Atto;     // Billionths of a nanosecond since the given nanosecond
+    unsigned int Ronto;    // Billionths of an attosecond since the given attosecond
+    unsigned int Udecto;   // Billionths of a rontosecond since the given rontosecond
+    unsigned int Xindecto; // Billionths of an udectosecond since the given udectosecond
+    unsigned int padding;  // round the value out to the nearest 64 bits
 } TAI64Time;
 
 typedef TAI64Time (*Calends_calendar_to_internal_string) (char*, char*, char*);
@@ -24,33 +24,33 @@ typedef TAI64Time (*Calends_calendar_offset_double) (char*, TAI64Time, double);
 typedef TAI64Time (*Calends_calendar_offset_tai) (char*, TAI64Time, TAI64Time);
 
 static inline TAI64Time bridge_Calends_calendar_to_internal_string(Calends_calendar_to_internal_string f, char* name, char* date, char* format) {
-  return f(name, date, format);
+    return f(name, date, format);
 }
 static inline TAI64Time bridge_Calends_calendar_to_internal_long_long(Calends_calendar_to_internal_long_long f, char* name, long long int date, char* format) {
-  return f(name, date, format);
+    return f(name, date, format);
 }
 static inline TAI64Time bridge_Calends_calendar_to_internal_double(Calends_calendar_to_internal_double f, char* name, double date, char* format) {
-  return f(name, date, format);
+    return f(name, date, format);
 }
 static inline TAI64Time bridge_Calends_calendar_to_internal_tai(Calends_calendar_to_internal_tai f, char* name, TAI64Time date) {
-  return f(name, date);
+    return f(name, date);
 }
 
 static inline char* bridge_Calends_calendar_from_internal(Calends_calendar_from_internal f, char* name, TAI64Time stamp, char* format) {
-  return f(name, stamp, format);
+    return f(name, stamp, format);
 }
 
 static inline TAI64Time bridge_Calends_calendar_offset_string(Calends_calendar_offset_string f, char* name, TAI64Time stamp, char* offset) {
-  return f(name, stamp, offset);
+    return f(name, stamp, offset);
 }
 static inline TAI64Time bridge_Calends_calendar_offset_long_long(Calends_calendar_offset_long_long f, char* name, TAI64Time stamp, long long int offset) {
-  return f(name, stamp, offset);
+    return f(name, stamp, offset);
 }
 static inline TAI64Time bridge_Calends_calendar_offset_double(Calends_calendar_offset_double f, char* name, TAI64Time stamp, double offset) {
-  return f(name, stamp, offset);
+    return f(name, stamp, offset);
 }
 static inline TAI64Time bridge_Calends_calendar_offset_tai(Calends_calendar_offset_tai f, char* name, TAI64Time stamp, TAI64Time offset) {
-  return f(name, stamp, offset);
+    return f(name, stamp, offset);
 }
 */
 import "C"
@@ -124,7 +124,7 @@ func TAI64Time_string(t C.TAI64Time) *C.char {
 
 //export TAI64Time_from_string
 func TAI64Time_from_string(in *C.char) C.TAI64Time {
-	return taiGoToC(calendars.TAI64NAXURTimeFromDecimalString(C.GoString(in)))
+	return taiGoToC(calendars.TAI64NARUXTimeFromDecimalString(C.GoString(in)))
 }
 
 //export TAI64Time_hex_string
@@ -135,7 +135,7 @@ func TAI64Time_hex_string(t C.TAI64Time) *C.char {
 
 //export TAI64Time_from_hex_string
 func TAI64Time_from_hex_string(in *C.char) C.TAI64Time {
-	return taiGoToC(calendars.TAI64NAXURTimeFromHexString(C.GoString(in)))
+	return taiGoToC(calendars.TAI64NARUXTimeFromHexString(C.GoString(in)))
 }
 
 //export TAI64Time_double
@@ -147,7 +147,7 @@ func TAI64Time_double(t C.TAI64Time) C.double {
 
 //export TAI64Time_from_double
 func TAI64Time_from_double(in C.double) C.TAI64Time {
-	return taiGoToC(calendars.TAI64NAXURTimeFromFloat(*big.NewFloat(float64(in))))
+	return taiGoToC(calendars.TAI64NARUXTimeFromFloat(*big.NewFloat(float64(in))))
 }
 
 //export TAI64Time_encode_text
@@ -163,7 +163,7 @@ func TAI64Time_encode_text(t C.TAI64Time) *C.char {
 
 //export TAI64Time_decode_text
 func TAI64Time_decode_text(in *C.char) C.TAI64Time {
-	time := calendars.TAI64NAXURTime{}
+	time := calendars.TAI64NARUXTime{}
 	time.UnmarshalText([]byte(C.GoString(in)))
 	return taiGoToC(time)
 }
@@ -182,7 +182,7 @@ func TAI64Time_encode_binary(t C.TAI64Time, length *C.int) unsafe.Pointer {
 
 //export TAI64Time_decode_binary
 func TAI64Time_decode_binary(in unsafe.Pointer, len C.int) C.TAI64Time {
-	time := calendars.TAI64NAXURTime{}
+	time := calendars.TAI64NARUXTime{}
 	time.UnmarshalBinary(C.GoBytes(in, len))
 	return taiGoToC(time)
 }
@@ -203,8 +203,8 @@ func wrapToInternal(
 	toInternalLongLong C.Calends_calendar_to_internal_long_long,
 	toInternalDouble C.Calends_calendar_to_internal_double,
 	toInternalTai C.Calends_calendar_to_internal_tai,
-) func(interface{}, string) (calendars.TAI64NAXURTime, error) {
-	return func(in interface{}, format string) (out calendars.TAI64NAXURTime, err error) {
+) func(interface{}, string) (calendars.TAI64NARUXTime, error) {
+	return func(in interface{}, format string) (out calendars.TAI64NARUXTime, err error) {
 		var raw C.TAI64Time
 		defer handlePanic()
 		switch in := in.(type) {
@@ -223,7 +223,7 @@ func wrapToInternal(
 			if err != nil {
 				err = errors.Wrap(err, 0)
 			}
-		case calendars.TAI64NAXURTime:
+		case calendars.TAI64NARUXTime:
 			pass := taiGoToC(in)
 			raw, err = C.bridge_Calends_calendar_to_internal_tai(toInternalTai, name, pass)
 			if err != nil {
@@ -241,8 +241,8 @@ func wrapToInternal(
 	}
 }
 
-func wrapFromInternal(name *C.char, fromInternal C.Calends_calendar_from_internal) func(calendars.TAI64NAXURTime, string) (string, error) {
-	return func(in calendars.TAI64NAXURTime, format string) (out string, err error) {
+func wrapFromInternal(name *C.char, fromInternal C.Calends_calendar_from_internal) func(calendars.TAI64NARUXTime, string) (string, error) {
+	return func(in calendars.TAI64NARUXTime, format string) (out string, err error) {
 		var raw *C.char
 		defer handlePanic()
 		pass := taiGoToC(in)
@@ -262,8 +262,8 @@ func wrapOffset(
 	offsetLongLong C.Calends_calendar_offset_long_long,
 	offsetDouble C.Calends_calendar_offset_double,
 	offsetTai C.Calends_calendar_offset_tai,
-) func(calendars.TAI64NAXURTime, interface{}) (calendars.TAI64NAXURTime, error) {
-	return func(in calendars.TAI64NAXURTime, offset interface{}) (out calendars.TAI64NAXURTime, err error) {
+) func(calendars.TAI64NARUXTime, interface{}) (calendars.TAI64NARUXTime, error) {
+	return func(in calendars.TAI64NARUXTime, offset interface{}) (out calendars.TAI64NARUXTime, err error) {
 		var raw C.TAI64Time
 		defer handlePanic()
 		pass := taiGoToC(in)
@@ -283,7 +283,7 @@ func wrapOffset(
 			if err != nil {
 				err = errors.Wrap(err, 0)
 			}
-		case calendars.TAI64NAXURTime:
+		case calendars.TAI64NARUXTime:
 			pass2 := taiGoToC(offset)
 			raw, err = C.bridge_Calends_calendar_offset_tai(offsetTai, name, pass, pass2)
 			if err != nil {
@@ -301,25 +301,25 @@ func wrapOffset(
 	}
 }
 
-func taiGoToC(in calendars.TAI64NAXURTime) C.TAI64Time {
+func taiGoToC(in calendars.TAI64NARUXTime) C.TAI64Time {
 	return C.TAI64Time{
-		Seconds: C.longlong(in.Seconds),
-		Nano:    C.uint(in.Nano),
-		Atto:    C.uint(in.Atto),
-		Xicto:   C.uint(in.Xicto),
-		Ucto:    C.uint(in.Ucto),
-		Rocto:   C.uint(in.Rocto),
-		padding: C.uint(0),
+		Seconds:  C.longlong(in.Seconds),
+		Nano:     C.uint(in.Nano),
+		Atto:     C.uint(in.Atto),
+		Ronto:    C.uint(in.Ronto),
+		Udecto:   C.uint(in.Udecto),
+		Xindecto: C.uint(in.Xindecto),
+		padding:  C.uint(0),
 	}
 }
 
-func taiCToGo(in C.TAI64Time) calendars.TAI64NAXURTime {
-	return calendars.TAI64NAXURTime{
-		Seconds: int64(in.Seconds),
-		Nano:    uint32(in.Nano),
-		Atto:    uint32(in.Atto),
-		Xicto:   uint32(in.Xicto),
-		Ucto:    uint32(in.Ucto),
-		Rocto:   uint32(in.Rocto),
+func taiCToGo(in C.TAI64Time) calendars.TAI64NARUXTime {
+	return calendars.TAI64NARUXTime{
+		Seconds:  int64(in.Seconds),
+		Nano:     uint32(in.Nano),
+		Atto:     uint32(in.Atto),
+		Ronto:    uint32(in.Ronto),
+		Udecto:   uint32(in.Udecto),
+		Xindecto: uint32(in.Xindecto),
 	}
 }

--- a/libcalends/calendars_tests.go
+++ b/libcalends/calendars_tests.go
@@ -5,9 +5,9 @@ typedef struct _TAI64Time {
         long long int Seconds; // Seconds since 1970-01-01 00:00:00 TAI
         unsigned int Nano;     // Nanoseconds since the given second
         unsigned int Atto;     // Attoseconds since the given nanosecond
-        unsigned int Xicto;    // Xictoseconds since the given attosecond
-        unsigned int Ucto;     // Uctoseconds since the given xictosecond
-        unsigned int Rocto;    // Roctoseconds since the given uctosecond
+        unsigned int Ronto;    // Rontoseconds since the given attosecond
+        unsigned int Udecto;     // Udectoseconds since the given rontosecond
+        unsigned int Xindecto;    // Xindectoseconds since the given udectosecond
 				unsigned int padding;  // round the value out to the nearest 64 bits
 } TAI64Time;
 

--- a/libcalends/comparisons_tests.go
+++ b/libcalends/comparisons_tests.go
@@ -38,7 +38,7 @@ func testCalends_is_same(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_same(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_is_same(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -51,7 +51,7 @@ func testCalends_is_same_duration(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_same_duration(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_is_same_duration(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -64,7 +64,7 @@ func testCalends_is_shorter(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_shorter(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_is_shorter(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -77,7 +77,7 @@ func testCalends_is_longer(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_longer(inst1, inst2)
-	if bool(ret) != true {
+	if !bool(ret) {
 		t.Errorf("Calends_is_longer(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), true)
 	}
 	Calends_release(inst1)
@@ -90,7 +90,7 @@ func testCalends_contains(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_contains(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_contains(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -103,7 +103,7 @@ func testCalends_overlaps(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_overlaps(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_overlaps(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -115,12 +115,22 @@ func testCalends_abuts(t *testing.T) {
 
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
+	inst3 := Calends_create_double_range(C.double(10.0), C.double(15.0), C.CString(""), C.CString(""))
 	ret := Calends_abuts(inst1, inst2)
-	if bool(ret) != false {
-		t.Errorf("Calends_abuts(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
+	if !bool(ret) {
+		t.Errorf("Calends_abuts(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), true)
+	}
+	ret = Calends_abuts(inst1, inst3)
+	if bool(ret) {
+		t.Errorf("Calends_abuts(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst3), bool(ret), false)
+	}
+	ret = Calends_abuts(inst2, inst3)
+	if !bool(ret) {
+		t.Errorf("Calends_abuts(%#v, %#v) returned %#v; wanted %#v", uint64(inst2), uint64(inst3), bool(ret), true)
 	}
 	Calends_release(inst1)
 	Calends_release(inst2)
+	Calends_release(inst3)
 }
 
 func testCalends_is_before(t *testing.T) {
@@ -129,7 +139,7 @@ func testCalends_is_before(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_before(inst1, inst2)
-	if bool(ret) != true {
+	if !bool(ret) {
 		t.Errorf("Calends_is_before(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), true)
 	}
 	Calends_release(inst1)
@@ -142,7 +152,7 @@ func testCalends_starts_before(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_starts_before(inst1, inst2)
-	if bool(ret) != true {
+	if !bool(ret) {
 		t.Errorf("Calends_starts_before(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), true)
 	}
 	Calends_release(inst1)
@@ -155,7 +165,7 @@ func testCalends_ends_before(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_ends_before(inst1, inst2)
-	if bool(ret) != true {
+	if !bool(ret) {
 		t.Errorf("Calends_ends_before(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), true)
 	}
 	Calends_release(inst1)
@@ -168,7 +178,7 @@ func testCalends_is_during(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_during(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_is_during(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -181,7 +191,7 @@ func testCalends_starts_during(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_starts_during(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_starts_during(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -194,7 +204,7 @@ func testCalends_ends_during(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_ends_during(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_ends_during(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -207,7 +217,7 @@ func testCalends_is_after(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_is_after(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_is_after(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -220,7 +230,7 @@ func testCalends_starts_after(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_starts_after(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_starts_after(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)
@@ -233,7 +243,7 @@ func testCalends_ends_after(t *testing.T) {
 	inst1 := Calends_create_double_range(C.double(0.0), C.double(5.0), C.CString(""), C.CString(""))
 	inst2 := Calends_create_double_range(C.double(5.0), C.double(10.0), C.CString(""), C.CString(""))
 	ret := Calends_ends_after(inst1, inst2)
-	if bool(ret) != false {
+	if bool(ret) {
 		t.Errorf("Calends_ends_after(%#v, %#v) returned %#v; wanted %#v", uint64(inst1), uint64(inst2), bool(ret), false)
 	}
 	Calends_release(inst1)

--- a/libcalends/dart/lib/src/generated_bindings.dart
+++ b/libcalends/dart/lib/src/generated_bindings.dart
@@ -1765,13 +1765,13 @@ class _TAI64Time extends ffi.Struct {
   external int Atto;
 
   @ffi.UnsignedInt()
-  external int Xicto;
+  external int Ronto;
 
   @ffi.UnsignedInt()
-  external int Ucto;
+  external int Udecto;
 
   @ffi.UnsignedInt()
-  external int Rocto;
+  external int Xindecto;
 
   @ffi.UnsignedInt()
   external int padding;

--- a/libcalends/dart/lib/src/util.dart
+++ b/libcalends/dart/lib/src/util.dart
@@ -17,7 +17,7 @@ CalendsBindings loadLib() {
   if (Platform.isMacOS) libraryName = 'libcalends.dylib';
   if (Platform.isWindows) libraryName = 'libcalends.dll';
 
-  final libraryPath = path.join(Directory.current.path, '..', libraryName);
+  final libraryPath = path.join(Directory.current.path, libraryName);
 
   return CalendsBindings(
     Platform.isIOS

--- a/libcalends/dart/test/calendar_definition_test.dart
+++ b/libcalends/dart/test/calendar_definition_test.dart
@@ -67,7 +67,7 @@ void main() {
       expect(test.date('fake', ''),
           equals('00000000000000000000000000000000000000000000000000000000'));
 
-      expect(test.add('1', 'fake').date('tai64', 'tai64naxur'),
+      expect(test.add('1', 'fake').date('tai64', 'tai64narux'),
           equals('-3FFFFFFFFFFFFFFF0000000000000000000000000000000000000000'));
 
       fake.unregister();

--- a/libcalends/dart/test/tai64time_test.dart
+++ b/libcalends/dart/test/tai64time_test.dart
@@ -19,16 +19,16 @@ void main() {
       expect(tai0.Atto, equals(0));
     });
 
-    test('Xicto', () {
-      expect(tai0.Xicto, equals(0));
+    test('Ronto', () {
+      expect(tai0.Ronto, equals(0));
     });
 
-    test('Ucto', () {
-      expect(tai0.Ucto, equals(0));
+    test('Udecto', () {
+      expect(tai0.Udecto, equals(0));
     });
 
-    test('Rocto', () {
-      expect(tai0.Rocto, equals(0));
+    test('Xindecto', () {
+      expect(tai0.Xindecto, equals(0));
     });
 
     test('toDouble', () {
@@ -51,16 +51,16 @@ void main() {
       expect(tai0.Atto, equals(0));
     });
 
-    test('Xicto', () {
-      expect(tai0.Xicto, equals(0));
+    test('Ronto', () {
+      expect(tai0.Ronto, equals(0));
     });
 
-    test('Ucto', () {
-      expect(tai0.Ucto, equals(0));
+    test('Udecto', () {
+      expect(tai0.Udecto, equals(0));
     });
 
-    test('Rocto', () {
-      expect(tai0.Rocto, equals(0));
+    test('Xindecto', () {
+      expect(tai0.Xindecto, equals(0));
     });
 
     test('toTAI64String', () {
@@ -84,16 +84,16 @@ void main() {
       expect(tai0.Atto, equals(0));
     });
 
-    test('Xicto', () {
-      expect(tai0.Xicto, equals(0));
+    test('Ronto', () {
+      expect(tai0.Ronto, equals(0));
     });
 
-    test('Ucto', () {
-      expect(tai0.Ucto, equals(0));
+    test('Udecto', () {
+      expect(tai0.Udecto, equals(0));
     });
 
-    test('Rocto', () {
-      expect(tai0.Rocto, equals(0));
+    test('Xindecto', () {
+      expect(tai0.Xindecto, equals(0));
     });
 
     test('toHex', () {
@@ -118,16 +118,16 @@ void main() {
       expect(tai0.Atto, equals(0));
     });
 
-    test('Xicto', () {
-      expect(tai0.Xicto, equals(0));
+    test('Ronto', () {
+      expect(tai0.Ronto, equals(0));
     });
 
-    test('Ucto', () {
-      expect(tai0.Ucto, equals(0));
+    test('Udecto', () {
+      expect(tai0.Udecto, equals(0));
     });
 
-    test('Rocto', () {
-      expect(tai0.Rocto, equals(0));
+    test('Xindecto', () {
+      expect(tai0.Xindecto, equals(0));
     });
 
     test('encodeText', () {
@@ -180,16 +180,16 @@ void main() {
       expect(tai0.Atto, equals(0));
     });
 
-    test('Xicto', () {
-      expect(tai0.Xicto, equals(0));
+    test('Ronto', () {
+      expect(tai0.Ronto, equals(0));
     });
 
-    test('Ucto', () {
-      expect(tai0.Ucto, equals(0));
+    test('Udecto', () {
+      expect(tai0.Udecto, equals(0));
     });
 
-    test('Rocto', () {
-      expect(tai0.Rocto, equals(0));
+    test('Xindecto', () {
+      expect(tai0.Xindecto, equals(0));
     });
 
     test('encodeBinary', () {

--- a/libcalends/php/src/TAITime.php
+++ b/libcalends/php/src/TAITime.php
@@ -11,9 +11,9 @@ final class TAITime
     public int $seconds = 0;
     public int $nano = 0;
     public int $atto = 0;
-    public int $xicto = 0;
-    public int $ucto = 0;
-    public int $rocto = 0;
+    public int $ronto = 0;
+    public int $udecto = 0;
+    public int $xindecto = 0;
 
     private static function ffiInit()
     {
@@ -34,9 +34,9 @@ final class TAITime
         $out->seconds = $stamp->Seconds;
         $out->nano = $stamp->Nano;
         $out->atto = $stamp->Atto;
-        $out->xicto = $stamp->Xicto;
-        $out->ucto = $stamp->Ucto;
-        $out->rocto = $stamp->Rocto;
+        $out->ronto = $stamp->Ronto;
+        $out->udecto = $stamp->Udecto;
+        $out->xindecto = $stamp->Xindecto;
 
         return $out;
     }
@@ -48,9 +48,9 @@ final class TAITime
         $out->Seconds = $this->seconds;
         $out->Nano = $this->nano;
         $out->Atto = $this->atto;
-        $out->Xicto = $this->xicto;
-        $out->Ucto = $this->ucto;
-        $out->Rocto = $this->rocto;
+        $out->Ronto = $this->ronto;
+        $out->Udecto = $this->udecto;
+        $out->Xindecto = $this->xindecto;
 
         return $out;
     }

--- a/libcalends/php/tests/040.taitime_create.phpt
+++ b/libcalends/php/tests/040.taitime_create.phpt
@@ -31,25 +31,11 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
-  int(0)
-}
-object(Calends\TAITime)#%d (6) {
-  ["seconds"]=>
-  int(0)
-  ["nano"]=>
-  int(0)
-  ["atto"]=>
-  int(0)
-  ["xicto"]=>
-  int(0)
-  ["ucto"]=>
-  int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }
 object(Calends\TAITime)#%d (6) {
@@ -59,25 +45,11 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
-  int(0)
-}
-object(Calends\TAITime)#%d (6) {
-  ["seconds"]=>
-  int(0)
-  ["nano"]=>
-  int(0)
-  ["atto"]=>
-  int(0)
-  ["xicto"]=>
-  int(0)
-  ["ucto"]=>
-  int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }
 object(Calends\TAITime)#%d (6) {
@@ -87,10 +59,38 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
+  int(0)
+}
+object(Calends\TAITime)#%d (6) {
+  ["seconds"]=>
+  int(0)
+  ["nano"]=>
+  int(0)
+  ["atto"]=>
+  int(0)
+  ["ronto"]=>
+  int(0)
+  ["udecto"]=>
+  int(0)
+  ["xindecto"]=>
+  int(0)
+}
+object(Calends\TAITime)#%d (6) {
+  ["seconds"]=>
+  int(0)
+  ["nano"]=>
+  int(0)
+  ["atto"]=>
+  int(0)
+  ["ronto"]=>
+  int(0)
+  ["udecto"]=>
+  int(0)
+  ["xindecto"]=>
   int(0)
 }

--- a/libcalends/php/tests/041.taitime_add.phpt
+++ b/libcalends/php/tests/041.taitime_add.phpt
@@ -24,10 +24,10 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }

--- a/libcalends/php/tests/042.taitime_sub.phpt
+++ b/libcalends/php/tests/042.taitime_sub.phpt
@@ -27,11 +27,11 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }
 object(Calends\TAITime)#%d (6) {
@@ -41,11 +41,11 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }
 object(Calends\TAITime)#%d (6) {
@@ -55,10 +55,10 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }

--- a/libcalends/php/tests/044.taitime_fromString.phpt
+++ b/libcalends/php/tests/044.taitime_fromString.phpt
@@ -23,10 +23,10 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }

--- a/libcalends/php/tests/046.taitime_fromHex.phpt
+++ b/libcalends/php/tests/046.taitime_fromHex.phpt
@@ -25,11 +25,11 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }
 object(Calends\TAITime)#%d (6) {
@@ -39,10 +39,10 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }

--- a/libcalends/php/tests/048.taitime_fromNumber.phpt
+++ b/libcalends/php/tests/048.taitime_fromNumber.phpt
@@ -25,11 +25,11 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }
 object(Calends\TAITime)#%d (6) {
@@ -39,10 +39,10 @@ object(Calends\TAITime)#%d (6) {
   int(0)
   ["atto"]=>
   int(0)
-  ["xicto"]=>
+  ["ronto"]=>
   int(0)
-  ["ucto"]=>
+  ["udecto"]=>
   int(0)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(0)
 }

--- a/libcalends/php/tests/049.taitime_toUTC.phpt
+++ b/libcalends/php/tests/049.taitime_toUTC.phpt
@@ -23,10 +23,10 @@ object(Calends\TAITime)#%d (6) {
   int(81999)
   ["atto"]=>
   int(999999027)
-  ["xicto"]=>
+  ["ronto"]=>
   int(295416453)
-  ["ucto"]=>
+  ["udecto"]=>
   int(853249549)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(865722656)
 }

--- a/libcalends/php/tests/050.taitime_fromUTC.phpt
+++ b/libcalends/php/tests/050.taitime_fromUTC.phpt
@@ -23,10 +23,10 @@ object(Calends\TAITime)#%d (6) {
   int(997489999)
   ["atto"]=>
   int(999999987)
-  ["xicto"]=>
+  ["ronto"]=>
   int(778664944)
-  ["ucto"]=>
+  ["udecto"]=>
   int(926276803)
-  ["rocto"]=>
+  ["xindecto"]=>
   int(16662598)
 }

--- a/offsets.go
+++ b/offsets.go
@@ -283,7 +283,7 @@ func emptyValue(in interface{}) (out bool) {
 		out = false
 	case float64:
 		out = false
-	case calendars.TAI64NAXURTime:
+	case calendars.TAI64NARUXTime:
 		out = false
 	default:
 		out = true
@@ -306,8 +306,8 @@ func negateOffset(in interface{}) (out interface{}) {
 		out = 0 - in
 	case float64:
 		out = 0.0 - in
-	case calendars.TAI64NAXURTime:
-		out = (calendars.TAI64NAXURTime{}).Sub(in)
+	case calendars.TAI64NARUXTime:
+		out = (calendars.TAI64NARUXTime{}).Sub(in)
 	default:
 		out = ""
 	}

--- a/offsets_test.go
+++ b/offsets_test.go
@@ -79,7 +79,7 @@ func TestSubtract(t *testing.T) {
 		t.Errorf("Subtract(%#v, %#v) has endTime of %#v\nwant %#v", "86400", "tai64", test.endTime.String(), "0")
 	}
 
-	test, err = testValue(0).Subtract(calendars.TAI64NAXURTime{}, "tai64")
+	test, err = testValue(0).Subtract(calendars.TAI64NARUXTime{}, "tai64")
 	if err != nil {
 		t.Errorf("Subtract(%#v, %#v) gives error %q", "86400", "tai64", err)
 	}
@@ -190,7 +190,7 @@ func TestSubtractFromEnd(t *testing.T) {
 		t.Errorf("SubtractFromEnd(%#v, %#v) has endTime of %#v\nwant %#v", "86400", "tai64", test.endTime.String(), "-86400")
 	}
 
-	test, err = testValue(0).SubtractFromEnd(calendars.TAI64NAXURTime{}, "tai64")
+	test, err = testValue(0).SubtractFromEnd(calendars.TAI64NARUXTime{}, "tai64")
 	if err != nil {
 		t.Errorf("SubtractFromEnd(%#v, %#v) gives error %q", "86400", "tai64", err)
 	}
@@ -239,7 +239,7 @@ func TestNext(t *testing.T) {
 	test1.Next([]byte(""), "")
 	test1.Next(0, "unix")
 	test1.Next(0.0, "unix")
-	test1.Next(calendars.TAI64NAXURTime{}, "unix")
+	test1.Next(calendars.TAI64NARUXTime{}, "unix")
 	test1.Next(nil, "unix")
 
 	if err1 != nil {

--- a/wasm/calendars.go
+++ b/wasm/calendars.go
@@ -1,0 +1,270 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"math/big"
+	"strings"
+	"syscall"
+	"syscall/js"
+
+	"github.com/danhunsaker/calends/calendars"
+	"github.com/go-errors/errors"
+)
+
+func CalendsCalendarRegister(this js.Value, args []js.Value) interface{} {
+	name := args[0].String()
+	defaultFormat := args[1].String()
+
+	toInternalString := args[2]
+	toInternalInt64 := args[3]
+	toInternalDouble := args[4]
+	toInternalTai := args[5]
+
+	fromInternal := args[6]
+
+	offsetString := args[7]
+	offsetInt64 := args[8]
+	offsetDouble := args[9]
+	offsetTai := args[10]
+
+	calendars.RegisterElements(
+		(name),
+		wrapToInternal(name, toInternalString, toInternalInt64, toInternalDouble, toInternalTai),
+		wrapFromInternal(name, fromInternal),
+		wrapOffset(name, offsetString, offsetInt64, offsetDouble, offsetTai),
+		(defaultFormat),
+	)
+
+	return js.Undefined()
+}
+
+func CalendsCalendarUnregister(this js.Value, args []js.Value) interface{} {
+	name := args[0].String()
+
+	calendars.Unregister((name))
+
+	return js.Undefined()
+}
+
+func CalendsCalendarRegistered(this js.Value, args []js.Value) interface{} {
+	calendar := args[0].String()
+
+	return js.ValueOf(calendars.Registered(calendar))
+}
+
+func CalendsCalendarListRegistered(this js.Value, args []js.Value) interface{} {
+	return js.ValueOf(strings.Join(calendars.ListRegistered(), "\n"))
+}
+
+func Tai64TimeAdd(this js.Value, args []js.Value) interface{} {
+	t := args[0]
+	z := args[1]
+
+	base := taiWASMToGo(t)
+	addend := taiWASMToGo(z)
+	return taiGoToWASM(base.Add(addend))
+}
+
+func Tai64TimeSub(this js.Value, args []js.Value) interface{} {
+	t := args[0]
+	z := args[1]
+
+	base := taiWASMToGo(t)
+	subtend := taiWASMToGo(z)
+	return taiGoToWASM(base.Sub(subtend))
+}
+
+func Tai64TimeString(this js.Value, args []js.Value) interface{} {
+	t := args[0]
+
+	base := taiWASMToGo(t)
+	return js.ValueOf(base.String())
+}
+
+func Tai64TimeFromString(this js.Value, args []js.Value) interface{} {
+	in := args[0].String()
+
+	return taiGoToWASM(calendars.TAI64NARUXTimeFromDecimalString((in)))
+}
+
+func Tai64TimeHexString(this js.Value, args []js.Value) interface{} {
+	t := args[0]
+
+	base := taiWASMToGo(t)
+	return js.ValueOf(base.HexString())
+}
+
+func Tai64TimeFromHexString(this js.Value, args []js.Value) interface{} {
+	in := args[0].String()
+
+	return taiGoToWASM(calendars.TAI64NARUXTimeFromHexString((in)))
+}
+
+func Tai64TimeDouble(this js.Value, args []js.Value) interface{} {
+	t := args[0]
+
+	base := taiWASMToGo(t)
+	out, _ := base.Float().Float64()
+	return js.ValueOf(out)
+}
+
+func Tai64TimeFromDouble(this js.Value, args []js.Value) interface{} {
+	in := args[0].Float()
+
+	return taiGoToWASM(calendars.TAI64NARUXTimeFromFloat(*big.NewFloat(in)))
+}
+
+func Tai64TimeEncodeText(this js.Value, args []js.Value) interface{} {
+	t := args[0]
+
+	base := taiWASMToGo(t)
+	out, err := base.MarshalText()
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(string(out))
+}
+
+func Tai64TimeDecodeText(this js.Value, args []js.Value) interface{} {
+	in := args[0].String()
+
+	time := calendars.TAI64NARUXTime{}
+	time.UnmarshalText([]byte((in)))
+	return taiGoToWASM(time)
+}
+
+func Tai64TimeUtcToTai(this js.Value, args []js.Value) interface{} {
+	utc := args[0]
+
+	return taiGoToWASM(calendars.UTCtoTAI(taiWASMToGo(utc)))
+}
+
+func Tai64TimeTaiToUtc(this js.Value, args []js.Value) interface{} {
+	tai := args[0]
+
+	return taiGoToWASM(calendars.TAItoUTC(taiWASMToGo(tai)))
+}
+
+func wrapToInternal(
+	name string,
+	toInternalString js.Value,
+	toInternalInt64 js.Value,
+	toInternalDouble js.Value,
+	toInternalTai js.Value,
+) func(interface{}, string) (calendars.TAI64NARUXTime, error) {
+	return func(in interface{}, format string) (out calendars.TAI64NARUXTime, err error) {
+		var raw js.Value
+		switch in := in.(type) {
+		case string:
+			raw = toInternalString.Invoke(name, (in), (format))
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		case int:
+			raw = toInternalInt64.Invoke(name, int64(in), (format))
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		case float64:
+			raw = toInternalDouble.Invoke(name, in, (format))
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		case calendars.TAI64NARUXTime:
+			pass := taiGoToWASM(in)
+			raw = toInternalTai.Invoke(name, pass)
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		default:
+			err = errors.Wrap(calendars.ErrUnsupportedInput, 1)
+		}
+		if err != nil && !errors.Is(err, syscall.Errno(2)) {
+			panic(err)
+		}
+		out = taiWASMToGo(raw)
+		err = nil
+		return
+	}
+}
+
+func wrapFromInternal(name string, fromInternal js.Value) func(calendars.TAI64NARUXTime, string) (string, error) {
+	return func(in calendars.TAI64NARUXTime, format string) (out string, err error) {
+		var raw js.Value
+		pass := taiGoToWASM(in)
+		raw = fromInternal.Invoke(name, pass, (format))
+		if err != nil && !errors.Is(err, syscall.Errno(2)) {
+			panic(errors.Wrap(err, 0))
+		}
+		out = (raw.String())
+		err = nil
+		return
+	}
+}
+
+func wrapOffset(
+	name string,
+	offsetString js.Value,
+	offsetInt64 js.Value,
+	offsetDouble js.Value,
+	offsetTai js.Value,
+) func(calendars.TAI64NARUXTime, interface{}) (calendars.TAI64NARUXTime, error) {
+	return func(in calendars.TAI64NARUXTime, offset interface{}) (out calendars.TAI64NARUXTime, err error) {
+		var raw js.Value
+		pass := taiGoToWASM(in)
+		switch offset := offset.(type) {
+		case string:
+			raw = offsetString.Invoke(name, pass, (offset))
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		case int:
+			raw = offsetInt64.Invoke(name, pass, int64(offset))
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		case float64:
+			raw = offsetDouble.Invoke(name, pass, offset)
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		case calendars.TAI64NARUXTime:
+			pass2 := taiGoToWASM(offset)
+			raw = offsetTai.Invoke(name, pass, pass2)
+			if err != nil {
+				err = errors.Wrap(err, 0)
+			}
+		default:
+			err = errors.Wrap(calendars.ErrUnsupportedInput, 1)
+		}
+		if err != nil && !errors.Is(err, syscall.Errno(2)) {
+			panic(err)
+		}
+		out = taiWASMToGo(raw)
+		err = nil
+		return
+	}
+}
+
+func taiGoToWASM(in calendars.TAI64NARUXTime) js.Value {
+	return js.ValueOf(map[string]interface{}{
+		"seconds":  js.ValueOf(in.Seconds),
+		"nano":     js.ValueOf(in.Nano),
+		"atto":     js.ValueOf(in.Atto),
+		"ronto":    js.ValueOf(in.Ronto),
+		"udecto":   js.ValueOf(in.Udecto),
+		"xindecto": js.ValueOf(in.Xindecto),
+	})
+}
+
+func taiWASMToGo(in js.Value) calendars.TAI64NARUXTime {
+	return calendars.TAI64NARUXTime{
+		Seconds:  int64(in.Get("seconds").Int()),
+		Nano:     uint32(in.Get("nano").Int()),
+		Atto:     uint32(in.Get("atto").Int()),
+		Ronto:    uint32(in.Get("ronto").Int()),
+		Udecto:   uint32(in.Get("udecto").Int()),
+		Xindecto: uint32(in.Get("xindecto").Int()),
+	}
+}

--- a/wasm/calends.go
+++ b/wasm/calends.go
@@ -1,0 +1,282 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"syscall/js"
+
+	"github.com/danhunsaker/calends"
+)
+
+var maxShards = uint64(64)
+
+type concurrentMap []*concurrentMapShard
+
+type concurrentMapShard struct {
+	items map[uint64]interface{}
+	sync.RWMutex
+}
+
+func newConcurrentMap() concurrentMap {
+	m := make(concurrentMap, maxShards)
+	for i := uint64(0); i < maxShards; i++ {
+		m[i] = &concurrentMapShard{items: make(map[uint64]interface{})}
+	}
+	return m
+}
+
+func (m concurrentMap) getShard(key uint64) *concurrentMapShard {
+	return m[key%maxShards]
+}
+
+func (m concurrentMap) Store(key uint64, value interface{}) {
+	shard := m.getShard(key)
+	shard.Lock()
+	shard.items[key] = value
+	shard.Unlock()
+}
+
+func (m concurrentMap) Load(key uint64) (interface{}, bool) {
+	shard := m.getShard(key)
+	shard.RLock()
+	val, ok := shard.items[key]
+	shard.RUnlock()
+	return val, ok
+}
+
+func (m concurrentMap) Length() (out uint64) {
+	for _, shard := range m {
+		shard.RLock()
+		out += uint64(len(shard.items))
+		shard.RUnlock()
+	}
+	return
+}
+
+func (m concurrentMap) All() (out []interface{}) {
+	for _, shard := range m {
+		shard.RLock()
+		for _, item := range shard.items {
+			out = append(out, item)
+		}
+		shard.RUnlock()
+	}
+	return
+}
+
+func (m concurrentMap) Delete(key uint64) {
+	shard := m.getShard(key)
+	shard.Lock()
+	delete(shard.items, key)
+	shard.Unlock()
+}
+
+type idGenerator struct {
+	id uint64
+}
+
+func (generator *idGenerator) Id() uint64 {
+	return atomic.AddUint64(&generator.id, 1)
+}
+
+var panicHandlers concurrentMap
+var nextPanHandle idGenerator
+var instances concurrentMap
+var nextInst idGenerator
+
+func instNum(c calends.Calends) uint64 {
+	p := nextInst.Id()
+	instances.Store(p, &c)
+	return p
+}
+
+func instGet(p uint64) *calends.Calends {
+	val, ok := instances.Load(p)
+	if !ok {
+		panic(fmt.Sprintf("Calends object #%d doesn't exist", p))
+	}
+	return val.(*calends.Calends)
+}
+
+func calends_create(stamp interface{}, calendar, format string) uint64 {
+	c, err := calends.Create(stamp, calendar, format)
+	if err != nil {
+		panic(err)
+	}
+	return instNum(c)
+}
+
+func handlePanic() {
+	var err string
+
+	if r := recover(); r != nil {
+		// If nothing has been registered to handle
+		// these error states, resume panicking!
+		if panicHandlers.Length() < 1 {
+			panic(r)
+		}
+
+		// We need a string to pass to the handler(s)
+		switch r := r.(type) {
+		case string:
+			err = r
+		case error:
+			err = r.Error()
+			// err = errors.Wrap(r, 2).ErrorStack()
+		default:
+			err = fmt.Sprintf("%#v", r)
+		}
+
+		// Call the handler(s)!
+		for _, handler := range panicHandlers.All() {
+			handler.(js.Value).Invoke([]js.Value{js.ValueOf(err)})
+		}
+	}
+}
+
+func main() {
+	defer handlePanic()
+
+	quit := make(chan struct{})
+	panicHandlers = newConcurrentMap()
+	instances = newConcurrentMap()
+
+	js.Global().Set("CalendsFuncs", js.ValueOf(map[string]interface{}{
+		// Calends Exports
+		"release": js.FuncOf(CalendsRelease),
+
+		"createString":            js.FuncOf(CalendsCreateString),
+		"createStringRange":       js.FuncOf(CalendsCreateStringRange),
+		"createStringStartPeriod": js.FuncOf(CalendsCreateStringStartPeriod),
+		"createStringEndPeriod":   js.FuncOf(CalendsCreateStringEndPeriod),
+
+		"createInt64":            js.FuncOf(CalendsCreateInt64),
+		"createInt64Range":       js.FuncOf(CalendsCreateInt64Range),
+		"createInt64StartPeriod": js.FuncOf(CalendsCreateInt64StartPeriod),
+		"createInt64EndPeriod":   js.FuncOf(CalendsCreateInt64EndPeriod),
+
+		"createDouble":            js.FuncOf(CalendsCreateDouble),
+		"createDoubleRange":       js.FuncOf(CalendsCreateDoubleRange),
+		"createDoubleStartPeriod": js.FuncOf(CalendsCreateDoubleStartPeriod),
+		"createDoubleEndPeriod":   js.FuncOf(CalendsCreateDoubleEndPeriod),
+
+		"date":     js.FuncOf(CalendsDate),
+		"duration": js.FuncOf(CalendsDuration),
+		"endDate":  js.FuncOf(CalendsEndDate),
+
+		"string":     js.FuncOf(CalendsString),
+		"decodeText": js.FuncOf(CalendsDecodeText),
+		"encodeText": js.FuncOf(CalendsEncodeText),
+		"decodeJson": js.FuncOf(CalendsDecodeJson),
+		"encodeJson": js.FuncOf(CalendsEncodeJson),
+
+		"registerPanicHandler": js.FuncOf(CalendsRegisterPanicHandler),
+
+		// Calends Offsets
+		"addString": js.FuncOf(CalendsAddString),
+		"addInt64":  js.FuncOf(CalendsAddInt64),
+		"addDouble": js.FuncOf(CalendsAddDouble),
+
+		"subtractString": js.FuncOf(CalendsSubtractString),
+		"subtractInt64":  js.FuncOf(CalendsSubtractInt64),
+		"subtractDouble": js.FuncOf(CalendsSubtractDouble),
+
+		"addFromEndString": js.FuncOf(CalendsAddFromEndString),
+		"addFromEndInt64":  js.FuncOf(CalendsAddFromEndInt64),
+		"addFromEndDouble": js.FuncOf(CalendsAddFromEndDouble),
+
+		"subtractFromEndString": js.FuncOf(CalendsSubtractFromEndString),
+		"subtractFromEndInt64":  js.FuncOf(CalendsSubtractFromEndInt64),
+		"subtractFromEndDouble": js.FuncOf(CalendsSubtractFromEndDouble),
+
+		"nextString": js.FuncOf(CalendsNextString),
+		"nextInt64":  js.FuncOf(CalendsNextInt64),
+		"nextDouble": js.FuncOf(CalendsNextDouble),
+
+		"previousString": js.FuncOf(CalendsPreviousString),
+		"previousInt64":  js.FuncOf(CalendsPreviousInt64),
+		"previousDouble": js.FuncOf(CalendsPreviousDouble),
+
+		"withDateString": js.FuncOf(CalendsWithDateString),
+		"withDateInt64":  js.FuncOf(CalendsWithDateInt64),
+		"withDateDouble": js.FuncOf(CalendsWithDateDouble),
+
+		"withEndDateString": js.FuncOf(CalendsWithEndDateString),
+		"withEndDateInt64":  js.FuncOf(CalendsWithEndDateInt64),
+		"withEndDateDouble": js.FuncOf(CalendsWithEndDateDouble),
+
+		"withDurationString": js.FuncOf(CalendsWithDurationString),
+		"withDurationInt64":  js.FuncOf(CalendsWithDurationInt64),
+		"withDurationDouble": js.FuncOf(CalendsWithDurationDouble),
+
+		"withDurationFromEndString": js.FuncOf(CalendsWithDurationFromEndString),
+		"withDurationFromEndInt64":  js.FuncOf(CalendsWithDurationFromEndInt64),
+		"withDurationFromEndDouble": js.FuncOf(CalendsWithDurationFromEndDouble),
+
+		"merge":     js.FuncOf(CalendsMerge),
+		"intersect": js.FuncOf(CalendsIntersect),
+		"gap":       js.FuncOf(CalendsGap),
+
+		// Calends Comparisons
+		"difference": js.FuncOf(CalendsDifference),
+
+		"compare": js.FuncOf(CalendsCompare),
+		"isSame":  js.FuncOf(CalendsIsSame),
+
+		"isShorter":      js.FuncOf(CalendsIsShorter),
+		"isSameDuration": js.FuncOf(CalendsIsSameDuration),
+		"isLonger":       js.FuncOf(CalendsIsLonger),
+
+		"isBefore": js.FuncOf(CalendsIsBefore),
+		"isDuring": js.FuncOf(CalendsIsDuring),
+		"isAfter":  js.FuncOf(CalendsIsAfter),
+
+		"startsBefore": js.FuncOf(CalendsStartsBefore),
+		"startsDuring": js.FuncOf(CalendsStartsDuring),
+		"startsAfter":  js.FuncOf(CalendsStartsAfter),
+
+		"endsBefore": js.FuncOf(CalendsEndsBefore),
+		"endsDuring": js.FuncOf(CalendsEndsDuring),
+		"endsAfter":  js.FuncOf(CalendsEndsAfter),
+
+		"contains": js.FuncOf(CalendsContains),
+		"overlaps": js.FuncOf(CalendsOverlaps),
+		"abuts":    js.FuncOf(CalendsAbuts),
+
+		// Calendar Definition
+		"calendarRegister":       js.FuncOf(CalendsCalendarRegister),
+		"calendarUnregister":     js.FuncOf(CalendsCalendarUnregister),
+		"calendarRegistered":     js.FuncOf(CalendsCalendarRegistered),
+		"calendarListRegistered": js.FuncOf(CalendsCalendarListRegistered),
+
+		// TAI64Time
+		"taiAdd": js.FuncOf(Tai64TimeAdd),
+		"taiSub": js.FuncOf(Tai64TimeSub),
+
+		"taiString":     js.FuncOf(Tai64TimeString),
+		"taiHexString":  js.FuncOf(Tai64TimeHexString),
+		"taiDouble":     js.FuncOf(Tai64TimeDouble),
+		"taiEncodeText": js.FuncOf(Tai64TimeEncodeText),
+
+		"taiFromString":    js.FuncOf(Tai64TimeFromString),
+		"taiFromHexString": js.FuncOf(Tai64TimeFromHexString),
+		"taiFromDouble":    js.FuncOf(Tai64TimeFromDouble),
+		"taiDecodeText":    js.FuncOf(Tai64TimeDecodeText),
+
+		"taiFromUtc": js.FuncOf(Tai64TimeUtcToTai),
+		"taiToUtc":   js.FuncOf(Tai64TimeTaiToUtc),
+
+		// Cleanup
+		"stop": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			quit <- struct{}{}
+			return js.Undefined()
+		}),
+	}))
+
+	<-quit
+
+	js.Global().Set(`CalendsFuncs`, js.Undefined())
+}

--- a/wasm/calends_exports.go
+++ b/wasm/calends_exports.go
@@ -1,0 +1,241 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"syscall/js"
+
+	"github.com/danhunsaker/calends"
+)
+
+func CalendsRelease(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+
+	instances.Delete(p)
+	return js.Undefined()
+}
+
+func CalendsCreateString(this js.Value, args []js.Value) interface{} {
+	stamp := args[0].String()
+	calendar := args[1].String()
+	format := args[2].String()
+
+	return js.ValueOf(calends_create(stamp, calendar, format))
+}
+
+func CalendsCreateStringRange(this js.Value, args []js.Value) interface{} {
+	start := args[0].String()
+	end := args[1].String()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"start": start,
+		"end":   end,
+	}, calendar, format))
+}
+
+func CalendsCreateStringStartPeriod(this js.Value, args []js.Value) interface{} {
+	start := args[0].String()
+	duration := args[1].String()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"start":    start,
+		"duration": duration,
+	}, calendar, format))
+}
+
+func CalendsCreateStringEndPeriod(this js.Value, args []js.Value) interface{} {
+	duration := args[0].String()
+	end := args[1].String()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"duration": duration,
+		"end":      end,
+	}, calendar, format))
+}
+
+func CalendsCreateInt64(this js.Value, args []js.Value) interface{} {
+	stamp := args[0].Int()
+	calendar := args[1].String()
+	format := args[2].String()
+
+	return js.ValueOf(calends_create(int(stamp), calendar, format))
+}
+
+func CalendsCreateInt64Range(this js.Value, args []js.Value) interface{} {
+	start := args[0].Int()
+	end := args[1].Int()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"start": int(start),
+		"end":   int(end),
+	}, calendar, format))
+}
+
+func CalendsCreateInt64StartPeriod(this js.Value, args []js.Value) interface{} {
+	start := args[0].Int()
+	duration := args[1].Int()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"start":    int(start),
+		"duration": int(duration),
+	}, calendar, format))
+}
+
+func CalendsCreateInt64EndPeriod(this js.Value, args []js.Value) interface{} {
+	duration := args[0].Int()
+	end := args[1].Int()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"duration": int(duration),
+		"end":      int(end),
+	}, calendar, format))
+}
+
+func CalendsCreateDouble(this js.Value, args []js.Value) interface{} {
+	stamp := args[0].Float()
+	calendar := args[1].String()
+	format := args[2].String()
+
+	return js.ValueOf(calends_create(float64(stamp), calendar, format))
+}
+
+func CalendsCreateDoubleRange(this js.Value, args []js.Value) interface{} {
+	start := args[0].Float()
+	end := args[1].Float()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"start": float64(start),
+		"end":   float64(end),
+	}, calendar, format))
+}
+
+func CalendsCreateDoubleStartPeriod(this js.Value, args []js.Value) interface{} {
+	start := args[0].Float()
+	duration := args[1].Float()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"start":    float64(start),
+		"duration": float64(duration),
+	}, calendar, format))
+}
+
+func CalendsCreateDoubleEndPeriod(this js.Value, args []js.Value) interface{} {
+	duration := args[0].Float()
+	end := args[1].Float()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return js.ValueOf(calends_create(map[string]interface{}{
+		"duration": float64(duration),
+		"end":      float64(end),
+	}, calendar, format))
+}
+
+func CalendsDate(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	calendar := args[1].String()
+	format := args[2].String()
+
+	c := instGet(p)
+	out, err := c.Date(calendar, format)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(out)
+}
+
+func CalendsDuration(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+
+	c := instGet(p)
+	return js.ValueOf(c.Duration().String())
+}
+
+func CalendsEndDate(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	calendar := args[1].String()
+	format := args[2].String()
+
+	c := instGet(p)
+	out, err := c.EndDate(calendar, format)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(out)
+}
+
+func CalendsString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+
+	c := instGet(p)
+	return js.ValueOf(c.String())
+}
+
+func CalendsEncodeText(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+
+	c := instGet(p)
+	out, err := c.MarshalText()
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(string(out))
+}
+
+func CalendsDecodeText(this js.Value, args []js.Value) interface{} {
+	in := args[0].String()
+
+	c := calends.Calends{}
+	err := c.UnmarshalText([]byte(in))
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(c))
+}
+
+func CalendsEncodeJson(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+
+	c := instGet(p)
+	out, err := c.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(string(out))
+}
+
+func CalendsDecodeJson(this js.Value, args []js.Value) interface{} {
+	in := args[0].String()
+
+	c := calends.Calends{}
+	err := c.UnmarshalJSON([]byte(in))
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(c))
+}
+
+func CalendsRegisterPanicHandler(this js.Value, args []js.Value) interface{} {
+	handler := args[0]
+
+	id := nextPanHandle.Id()
+	panicHandlers.Store(id, handler)
+
+	return js.Undefined()
+}

--- a/wasm/comparisons.go
+++ b/wasm/comparisons.go
@@ -1,0 +1,170 @@
+//go:build js && wasm
+
+package main
+
+import "syscall/js"
+
+func CalendsDifference(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+	mode := args[2].String()
+
+	c := instGet(p1)
+	z := instGet(p2)
+	out := c.Difference(*z, mode)
+	return js.ValueOf(out.String())
+}
+
+func CalendsCompare(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+	mode := args[2].String()
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(int8(c.Compare(*z, mode)))
+}
+
+func CalendsIsSame(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsSame(*z))
+}
+
+func CalendsIsSameDuration(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsSameDuration(*z))
+}
+
+func CalendsIsShorter(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsShorter(*z))
+}
+
+func CalendsIsLonger(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsLonger(*z))
+}
+
+func CalendsContains(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.Contains(*z))
+}
+
+func CalendsOverlaps(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.Overlaps(*z))
+}
+
+func CalendsAbuts(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.Abuts(*z))
+}
+
+func CalendsIsBefore(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsBefore(*z))
+}
+
+func CalendsStartsBefore(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.StartsBefore(*z))
+}
+
+func CalendsEndsBefore(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.EndsBefore(*z))
+}
+
+func CalendsIsDuring(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsDuring(*z))
+}
+
+func CalendsStartsDuring(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.StartsDuring(*z))
+}
+
+func CalendsEndsDuring(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.EndsDuring(*z))
+}
+
+func CalendsIsAfter(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.IsAfter(*z))
+}
+
+func CalendsStartsAfter(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.StartsAfter(*z))
+}
+
+func CalendsEndsAfter(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	return js.ValueOf(c.EndsAfter(*z))
+}

--- a/wasm/js/.gitignore
+++ b/wasm/js/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+# /package-lock.json

--- a/wasm/js/calends.js
+++ b/wasm/js/calends.js
@@ -1,0 +1,903 @@
+// Stolen from Emscripten boilerplate
+const ENVIRONMENT_IS_WEB = typeof window === 'object';
+const ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
+const ENVIRONMENT_HAS_NODE = typeof process === 'object' && typeof process.versions === 'object' && typeof process.versions.node === 'string';
+const ENVIRONMENT_IS_NODE = ENVIRONMENT_HAS_NODE && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
+const ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
+
+var scriptDirectory = '';
+function locateFile(path) {
+    return scriptDirectory + path;
+}
+
+var read_, readAsync, readBinary, onDestroy;
+
+if (ENVIRONMENT_IS_NODE) {
+    const { addDestructor } = require('object-destructor');
+    require('./wasm_loader');
+
+    scriptDirectory = __dirname + '/';
+
+    // Expose functionality in the same simple way that the shells work
+    // Note that we pollute the global namespace here, otherwise we break in node
+    var nodeFS;
+    var nodePath;
+
+    read_ = function shell_read(filename, binary) {
+        var ret;
+        if (!nodeFS) nodeFS = require('fs');
+        if (!nodePath) nodePath = require('path');
+        filename = nodePath['normalize'](filename);
+        ret = nodeFS['readFileSync'](filename);
+        return binary ? ret : ret.toString();
+    };
+
+    readBinary = function readBinary(filename) {
+        var ret = read_(filename, true);
+        if (!ret.buffer) {
+            ret = new Uint8Array(ret);
+        }
+        return ret;
+    };
+
+    onDestroy = addDestructor;
+} else if (ENVIRONMENT_IS_SHELL) {
+    const { addDestructor } = require('object-destructor');
+    require('./wasm_loader');
+
+    if (typeof read != 'undefined') {
+        read_ = function shell_read(f) {
+            return read(f);
+        };
+    }
+
+    readBinary = function readBinary(f) {
+        var data;
+        if (typeof readbuffer === 'function') {
+            return new Uint8Array(readbuffer(f));
+        }
+        data = read(f, 'binary');
+        return data;
+    };
+
+    if (typeof print !== 'undefined') {
+        // Prefer to use print/printErr where they exist, as they usually work better.
+        if (typeof console === 'undefined') console = {};
+        console.log = print;
+        console.warn = console.error = typeof printErr !== 'undefined' ? printErr : print;
+    }
+
+    onDestroy = addDestructor;
+} else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
+    if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
+        scriptDirectory = self.location.href;
+    } else if (document.currentScript) { // web
+        scriptDirectory = document.currentScript.src;
+    }
+    // blob urls look like blob:http://site.com/etc/etc and we cannot infer anything from them.
+    // otherwise, slice off the final part of the url to find the script directory.
+    // if scriptDirectory does not contain a slash, lastIndexOf will return -1,
+    // and scriptDirectory will correctly be replaced with an empty string.
+    if (scriptDirectory.indexOf('blob:') !== 0) {
+        scriptDirectory = scriptDirectory.substr(0, scriptDirectory.lastIndexOf('/') + 1);
+    } else {
+        scriptDirectory = '';
+    }
+
+    read_ = function shell_read(url) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url, false);
+        xhr.send(null);
+        return xhr.responseText;
+    };
+
+    if (ENVIRONMENT_IS_WORKER) {
+        readBinary = function readBinary(url) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', url, false);
+            xhr.responseType = 'arraybuffer';
+            xhr.send(null);
+            return new Uint8Array(xhr.response);
+        };
+    }
+
+    readAsync = function readAsync(url, onload, onerror) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.responseType = 'arraybuffer';
+        xhr.onload = function xhr_onload() {
+            if (xhr.status == 200 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
+                onload(xhr.response);
+                return;
+            }
+            onerror();
+        };
+        xhr.onerror = onerror;
+        xhr.send(null);
+    };
+
+    onDestroy = addDestructor;
+} else {
+    throw new Error('environment detection error');
+}
+
+// No longer stolen code
+const go = new globalThis.Go();
+let mod, inst;
+let halt = true;
+
+function initCalends(callback) {
+    if (!halt) return;
+    halt = false;
+
+    if (!(mod instanceof WebAssembly.Module)) {
+        (
+            typeof readAsync === 'function' ?
+                WebAssembly.instantiateStreaming(fetch(locateFile('calends.wasm')), go.importObject) :
+                WebAssembly.instantiate(readBinary(locateFile('calends.wasm')), go.importObject)
+        )
+        .then((result) => {
+            mod = result.module;
+            inst = result.instance;
+            run(); // Don't await because we need to run concurrent with the Go runtime
+            waitForCalendsFuncs().then(() => {
+                globalThis.CalendsFuncs.registerPanicHandler((message) => {
+                    throw new CalendsError(message);
+                });
+                if (typeof callback == 'function') callback();
+            });
+        }).catch((err) => {
+            throw new CalendsError(err);
+        });
+    } else {
+        run();
+        waitForCalendsFuncs().then(() => {
+            globalThis.CalendsFuncs.registerPanicHandler((message) => {
+                throw new CalendsError(message);
+            });
+            if (typeof callback == 'function') callback();
+        });
+    }
+
+    async function idleFor(msec) {
+        return new Promise(resolve => setTimeout(resolve, msec));
+    }
+
+    function waitForCalendsFuncs() {
+        return new Promise(async function (resolve) {
+            while (typeof globalThis.CalendsFuncs === 'undefined') {
+                await idleFor(500);
+            }
+
+            resolve();
+        });
+    }
+
+    async function run() {
+        if (!halt) {
+            try {
+                await go.run(inst);
+                inst = await WebAssembly.instantiate(mod, go.importObject); // reset instance
+                if (!halt) {
+                    initCalends();
+                }
+            } catch(err) {
+                throw CalendsError(err);
+            }
+        }
+    }
+}
+
+function stopCalends(callback) {
+    if (halt) return;
+    halt = true;
+    globalThis.CalendsFuncs.stop();
+    waitForCalendsFuncsToVanish().then(() => {
+        if (typeof callback == 'function') callback();
+    });
+
+    async function idleFor(msec) {
+        return new Promise(resolve => setTimeout(resolve, msec));
+    }
+
+    function waitForCalendsFuncsToVanish() {
+        return new Promise(async function (resolve) {
+            while (typeof globalThis.CalendsFuncs !== 'undefined') {
+                await idleFor(500);
+            }
+
+            resolve();
+        });
+    }
+}
+
+class CalendsError extends Error {}
+
+class Calends {
+    #instance;
+
+    // CREATE
+
+    constructor(stamp, calendar, format) {
+        let ref = 0;
+
+        if (typeof stamp == 'bigint' && !calendar && !format) {
+            ref = Number(stamp);
+        } else {
+            switch (typeof stamp) {
+                case 'string':
+                    ref = globalThis.CalendsFuncs.createString(stamp, calendar, format);
+                    break;
+
+                case 'number':
+                    if (Number.isInteger(stamp))
+                        ref = globalThis.CalendsFuncs.createInt64(stamp, calendar, format);
+                    else
+                        ref = globalThis.CalendsFuncs.createDouble(stamp, calendar, format);
+                    break;
+                    
+                case 'object':
+                    if (Object.keys(stamp).includes('start') && Object.keys(stamp).includes('end')) {
+                        switch (typeof stamp.start) {
+                            case 'string':
+                                ref = globalThis.CalendsFuncs.createStringRange(stamp.start, stamp.end, calendar, format);
+                                break;
+
+                            case 'number':
+                                if (Number.isInteger(stamp.start))
+                                    ref = globalThis.CalendsFuncs.createInt64Range(stamp.start, stamp.end, calendar, format);
+                                else
+                                    ref = globalThis.CalendsFuncs.createDoubleRange(stamp.start, stamp.end, calendar, format);
+                                break;
+
+                            default:
+                                throw new CalendsError(`Unsupported timestamp type: ${typeof stamp.start}`);
+                        }
+                    } else if (Object.keys(stamp).includes('start') && Object.keys(stamp).includes('duration')) {
+                        switch (typeof stamp.start) {
+                            case 'string':
+                                ref = globalThis.CalendsFuncs.createStringStartPeriod(stamp.start, stamp.duration, calendar, format);
+                                break;
+
+                            case 'number':
+                                if (Number.isInteger(stamp.start))
+                                    ref = globalThis.CalendsFuncs.createInt64StartPeriod(stamp.start, stamp.duration, calendar, format);
+                                else
+                                    ref = globalThis.CalendsFuncs.createDoubleStartPeriod(stamp.start, stamp.duration, calendar, format);
+                                break;
+
+                            default:
+                                throw new CalendsError(`Unsupported timestamp type: ${typeof stamp.start}`);
+                        }
+                    } else if (Object.keys(stamp).includes('duration') && Object.keys(stamp).includes('end')) {
+                        switch (typeof stamp.end) {
+                            case 'string':
+                                ref = globalThis.CalendsFuncs.createStringEndPeriod(stamp.duration, stamp.end, calendar, format);
+                                break;
+
+                            case 'number':
+                                if (Number.isInteger(stamp.end))
+                                    ref = globalThis.CalendsFuncs.createInt64EndPeriod(stamp.duration, stamp.end, calendar, format);
+                                else
+                                    ref = globalThis.CalendsFuncs.createDoubleEndPeriod(stamp.duration, stamp.end, calendar, format);
+                                break;
+
+                            default:
+                                throw new CalendsError(`Unsupported timestamp type: ${typeof stamp.end}`);
+                        }
+                    } else {
+                        throw new CalendsError(`Unsupported timestamp type: ${JSON.stringify(stamp)}`);
+                    }
+                    break;
+
+                default:
+                    throw new CalendsError(`Unsupported timestamp type: ${typeof stamp}`);
+            }
+        }
+
+        this.#instance = onDestroy(() => ({ ref }), () => { if (!halt) globalThis.CalendsFuncs.release(ref); });
+    }
+
+    static fromText(stamp) {
+        return new Calends(BigInt(globalThis.CalendsFuncs.decodeText(stamp)));
+    }
+
+    static fromJson(stamp) {
+        return new Calends(BigInt(globalThis.CalendsFuncs.decodeJson(stamp)));
+    }
+
+    // For Use With JSON.decode()
+
+    static reviver(key, value) {
+        if ((typeof value == 'string') || (typeof value == 'object' && typeof value.start == 'string' && typeof value.end == 'string')) {
+            return new Calends(value, 'tai64', 'tai64narux');
+        }
+
+        return value;
+    }
+
+    // READ
+
+    date(calendar, format) {
+        return globalThis.CalendsFuncs.date(this.#instance.ref, calendar, format);
+    }
+
+    duration() {
+        return globalThis.CalendsFuncs.duration(this.#instance.ref);
+    }
+
+    endDate(calendar, format) {
+        return globalThis.CalendsFuncs.endDate(this.#instance.ref, calendar, format);
+    }
+
+    toText() {
+        return globalThis.CalendsFuncs.encodeText(this.#instance.ref);
+    }
+
+    toJson() {
+        return globalThis.CalendsFuncs.encodeJson(this.#instance.ref);
+    }
+
+    // Treated Specially By JS
+
+    toString() {
+        return globalThis.CalendsFuncs.string(this.#instance.ref);
+    }
+
+    toJSON() {
+        return JSON.parse(this.toJson());
+    }
+
+    // "UPDATE" (actually returns new object)
+
+    add(offset, calendar) {
+        let ret;
+
+        switch (typeof offset) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.addString(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.addInt64(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.addDouble(this.#instance.ref, offset, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported offset type');
+        }
+
+        return ret;
+    }
+
+    addFromEnd(offset, calendar) {
+        let ret;
+
+        switch (typeof offset) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.addFromEndString(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.addFromEndInt64(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.addFromEndDouble(this.#instance.ref, offset, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported offset type');
+        }
+
+        return ret;
+    }
+
+    subtract(offset, calendar) {
+        let ret;
+
+        switch (typeof offset) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.subtractString(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.subtractInt64(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.subtractDouble(this.#instance.ref, offset, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported offset type');
+        }
+
+        return ret;
+    }
+
+    subtractFromEnd(offset, calendar) {
+        let ret;
+
+        switch (typeof offset) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.subtractFromEndString(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.subtractFromEndInt64(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.subtractFromEndDouble(this.#instance.ref, offset, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported offset type');
+        }
+
+        return ret;
+    }
+
+    next(offset, calendar) {
+        let ret;
+
+        switch (typeof offset) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.nextString(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.nextInt64(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.nextDouble(this.#instance.ref, offset, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported offset type');
+        }
+
+        return ret;
+    }
+
+    previous(offset, calendar) {
+        let ret;
+
+        switch (typeof offset) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.previousString(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.previousInt64(this.#instance.ref, offset, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.previousDouble(this.#instance.ref, offset, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported offset type');
+        }
+
+        return ret;
+    }
+
+    withDate(stamp, calendar, format) {
+        let ret;
+
+        switch (typeof stamp) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDateString(this.#instance.ref, stamp, calendar, format)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDateInt64(this.#instance.ref, stamp, calendar, format)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDateDouble(this.#instance.ref, stamp, calendar, format)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported stamp type');
+        }
+
+        return ret;
+    }
+
+    withEndDate(stamp, calendar, format) {
+        let ret;
+
+        switch (typeof stamp) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withEndDateString(this.#instance.ref, stamp, calendar, format)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withEndDateInt64(this.#instance.ref, stamp, calendar, format)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withEndDateDouble(this.#instance.ref, stamp, calendar, format)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported stamp type');
+        }
+
+        return ret;
+    }
+
+    withDuration(duration, calendar) {
+        let ret;
+
+        switch (typeof duration) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDurationString(this.#instance.ref, duration, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDurationInt64(this.#instance.ref, duration, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDurationDouble(this.#instance.ref, duration, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported duration type');
+        }
+
+        return ret;
+    }
+
+    withDurationFromEnd(duration, calendar) {
+        let ret;
+
+        switch (typeof duration) {
+            case 'string':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDurationFromEndString(this.#instance.ref, duration, calendar)));
+                break;
+
+            case 'bigint':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDurationFromEndInt64(this.#instance.ref, duration, calendar)));
+                break;
+
+            case 'number':
+                ret = new Calends(BigInt(globalThis.CalendsFuncs.withDurationFromEndDouble(this.#instance.ref, duration, calendar)));
+                break;
+
+            default:
+                throw new CalendsError('Unsupported duration type');
+        }
+
+        return ret;
+    }
+
+    merge(other) {
+        if (other instanceof Calends)
+            return new Calends(BigInt(globalThis.CalendsFuncs.merge(this.#instance.ref, other.#instance.ref)));
+
+        throw new CalendsError('Merge requires a Calends object as an argument');
+    }
+
+    intersect(other) {
+        if (other instanceof Calends)
+            return new Calends(BigInt(globalThis.CalendsFuncs.intersect(this.#instance.ref, other.#instance.ref)));
+
+        throw new CalendsError('Intersect requires a Calends object as an argument');
+    }
+
+    gap(other) {
+        if (other instanceof Calends)
+            return new Calends(BigInt(globalThis.CalendsFuncs.gap(this.#instance.ref, other.#instance.ref)));
+
+        throw new CalendsError('Gap requires a Calends object as an argument');
+    }
+
+    // COMPARE
+
+    difference(other, mode) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.difference(this.#instance.ref, other.#instance.ref, mode);
+
+        throw new CalendsError('Difference requires a Calends object as a first argument');
+    }
+
+    compare(other, mode) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.compare(this.#instance.ref, other.#instance.ref, mode);
+
+        throw new CalendsError('Compare requires a Calends object as a first argument');
+    }
+
+    isSame(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isSame(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsSame requires a Calends object as an argument');
+    }
+
+    isSameDuration(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isSameDuration(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsSameDuration requires a Calends object as an argument');
+    }
+
+    isShorter(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isShorter(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsShorter requires a Calends object as an argument');
+    }
+
+    isLonger(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isLonger(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsLonger requires a Calends object as an argument');
+    }
+
+    isBefore(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isBefore(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsBefore requires a Calends object as an argument');
+    }
+
+    isDuring(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isDuring(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsDuring requires a Calends object as an argument');
+    }
+
+    isAfter(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.isAfter(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('IsAfter requires a Calends object as an argument');
+    }
+
+    startsBefore(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.startsBefore(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('StartsBefore requires a Calends object as an argument');
+    }
+
+    startsDuring(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.startsDuring(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('StartsDuring requires a Calends object as an argument');
+    }
+
+    startsAfter(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.startsAfter(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('StartsAfter requires a Calends object as an argument');
+    }
+
+    endsBefore(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.endsBefore(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('EndsBefore requires a Calends object as an argument');
+    }
+
+    endsDuring(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.endsDuring(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('EndsDuring requires a Calends object as an argument');
+    }
+
+    endsAfter(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.endsAfter(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('EndsAfter requires a Calends object as an argument');
+    }
+
+    contains(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.contains(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('Contains requires a Calends object as an argument');
+    }
+
+    overlaps(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.overlaps(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('Overlaps requires a Calends object as an argument');
+    }
+
+    abuts(other) {
+        if (other instanceof Calends)
+            return globalThis.CalendsFuncs.abuts(this.#instance.ref, other.#instance.ref);
+
+        throw new CalendsError('Abuts requires a Calends object as an argument');
+    }
+}
+
+class TAI64Time {
+    seconds;
+    nano;
+    atto;
+    ronto;
+    udecto;
+    xindecto;
+
+    // CREATE
+
+    constructor({ seconds, nano, atto, ronto, udecto, xindecto } = {}) {
+        this.seconds = seconds || 0;
+        this.nano = nano || 0;
+        this.atto = atto || 0;
+        this.ronto = ronto || 0;
+        this.udecto = udecto || 0;
+        this.xindecto = xindecto || 0;
+    }
+
+    static fromString(raw) {
+        return new TAI64Time(globalThis.CalendsFuncs.taiFromString(raw));
+    }
+
+    static fromHex(raw) {
+        return new TAI64Time(globalThis.CalendsFuncs.taiFromHexString(raw));
+    }
+
+    static fromNumber(raw) {
+        return new TAI64Time(globalThis.CalendsFuncs.taiFromDouble(raw));
+    }
+
+    static fromText(raw) {
+        return new TAI64Time(globalThis.CalendsFuncs.taiDecodeText(raw));
+    }
+
+    // READ
+
+    toString() {
+        return globalThis.CalendsFuncs.taiString(this);
+    }
+
+    toHex() {
+        return globalThis.CalendsFuncs.taiHexString(this);
+    }
+
+    toNumber() {
+        return globalThis.CalendsFuncs.taiDouble(this);
+    }
+
+    toText() {
+        return globalThis.CalendsFuncs.taiEncodeText(this);
+    }
+
+    // "UPDATE" (returns new object)
+
+    add(instant) {
+        return new TAI64Time(globalThis.CalendsFuncs.taiAdd(this, instant));
+    }
+
+    sub(instant) {
+        return new TAI64Time(globalThis.CalendsFuncs.taiSub(this, instant));
+    }
+
+    toUTC() {
+        return new TAI64Time(globalThis.CalendsFuncs.taiToUtc(this));
+    }
+
+    fromUTC() {
+        return new TAI64Time(globalThis.CalendsFuncs.taiFromUtc(this));
+    }
+}
+
+class CalendarDefinition {
+    // SET ME
+    name;
+    // SET ME
+    defaultFormat;
+
+    #toInternalStringWrap(name, stamp, format) {
+        return this.toInternal(stamp, format);
+    }
+
+    #toInternalBigIntWrap(name, stamp, format) {
+        return this.toInternal(stamp, format);
+    }
+
+    #toInternalDoubleWrap(name, stamp, format) {
+        return this.toInternal(stamp, format);
+    }
+
+    #toInternalTaiWrap(name, stamp) {
+        return this.toInternal(new TAI64Time(stamp));
+    }
+
+    #fromInternalWrap(name, instant, format) {
+        return this.fromInternal(new TAI64Time(instant), format);
+    }
+
+    #offsetStringWrap(name, instant, offset) {
+        return this.offset(new TAI64Time(instant), offset);
+    }
+
+    #offsetBigIntWrap(name, instant, offset) {
+        return this.offset(new TAI64Time(instant), offset);
+    }
+
+    #offsetDoubleWrap(name, instant, offset) {
+        return this.offset(new TAI64Time(instant), offset);
+    }
+
+    #offsetTaiWrap(name, instant, offset) {
+        return this.offset(new TAI64Time(instant), new TAI64Time(offset));
+    }
+
+    // IMPLEMENT ME
+    constructor() {
+        if (this.constructor === CalendarDefinition)
+            throw new CalendsError("Don't directly create a CalendarDefinition object - use a subclass instead");
+    }
+
+    // IMPLEMENT ME
+    toInternal(stamp, format) {
+        throw new CalendsError('toInternal NOT IMPLEMENTED - Something is very wrong');
+    }
+
+    // IMPLEMENT ME
+    fromInternal(instant, format) {
+        throw new CalendsError('fromInternal NOT IMPLEMENTED - Something is very wrong');
+    }
+
+    // IMPLEMENT ME
+    offset(instant, offset) {
+        throw new CalendsError('offset NOT IMPLEMENTED - Something is very wrong');
+    }
+
+    register() {
+        globalThis.CalendsFuncs.calendarRegister(
+            this.name, this.defaultFormat,
+            this.#toInternalStringWrap, this.#toInternalBigIntWrap, this.#toInternalDoubleWrap, this.#toInternalTaiWrap,
+            this.#fromInternalWrap,
+            this.#offsetStringWrap, this.#offsetBigIntWrap, this.#offsetDoubleWrap, this.#offsetTaiWrap,
+        );
+    }
+
+    static registered() {
+        return String(globalThis.CalendsFuncs.calendarListRegistered()).split('\n');
+    }
+
+    static checkRegistered(name) {
+        return globalThis.CalendsFuncs.calendarRegistered(name);
+    }
+
+    isRegistered() {
+        return globalThis.CalendsFuncs.calendarRegistered(this.name);
+    }
+
+    unregister() {
+        globalThis.CalendsFuncs.calendarUnregister(this.name);
+    }
+}
+
+if (ENVIRONMENT_IS_NODE) {
+    module.exports = {
+        Calends,
+        CalendsError,
+        CalendarDefinition,
+        TAI64Time,
+        initCalends,
+        stopCalends,
+    }
+}

--- a/wasm/js/jsconfig.json
+++ b/wasm/js/jsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "ESNext",
+        "moduleResolution": "Node",
+        "target": "ES2020",
+        "jsx": "react",
+        "strictNullChecks": true,
+        "strictFunctionTypes": true
+    },
+    "exclude": [
+        "node_modules",
+        "**/node_modules/*"
+    ]
+}

--- a/wasm/js/package-lock.json
+++ b/wasm/js/package-lock.json
@@ -1,0 +1,1009 @@
+{
+  "name": "calends",
+  "version": "0.0.6",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calends",
+      "version": "0.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "object-destructor": "danhunsaker/javascript-object-destructor"
+      },
+      "devDependencies": {
+        "chai": "^4.3.7",
+        "mocha": "^10.2.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-destructor": {
+      "version": "0.1.1",
+      "resolved": "git+ssh://git@github.com/danhunsaker/javascript-object-destructor.git#e6bf18605b4bb4e58a6ab850aac2d3e00cdd0c33",
+      "license": "GPL-3.0-or-later"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/wasm/js/package.json
+++ b/wasm/js/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "calends",
+  "version": "0.0.6",
+  "description": "A library for handling dates and times across arbitrary calendar systems",
+  "scripts": {
+    "test": "mocha tests.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danhunsaker/calends"
+  },
+  "author": "Hennik Hunsaker <hennik@insidiouslogic.systems>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/danhunsaker/calends/issues"
+  },
+  "homepage": "https://github.com/danhunsaker/calends#readme",
+  "dependencies": {
+    "object-destructor": "danhunsaker/javascript-object-destructor"
+  },
+  "devDependencies": {
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0"
+  }
+}

--- a/wasm/js/tests.html
+++ b/wasm/js/tests.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+
+<head>
+	<meta charset="utf-8" />
+	<title>Mocha Tests</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
+</head>
+
+<body>
+	<div id="mocha"></div>
+
+	<script src="https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js"></script>
+	<script src="https://unpkg.com/chai/chai.js"></script>
+	<script src="https://unpkg.com/mocha/mocha.js"></script>
+
+	<script class="mocha-init">
+		mocha.setup('bdd');
+	</script>
+
+	<script src="wasm_loader.js"></script>
+	<script src="node_modules/object-destructor/index.js"></script>
+	<script src="calends.js"></script>
+	<script src="tests.js"></script>
+</body>
+
+</html>

--- a/wasm/js/tests.js
+++ b/wasm/js/tests.js
@@ -1,0 +1,844 @@
+{
+  const IS_WEB = typeof window === 'object';
+  const IS_WORKER = typeof importScripts === 'function';
+  const HAS_NODE = typeof process === 'object' && typeof process.versions === 'object' && typeof process.versions.node === 'string';
+  const IS_NODE = HAS_NODE && !IS_WEB && !IS_WORKER;
+  const IS_SHELL = !IS_WEB && !IS_NODE && !IS_WORKER;
+
+  if (IS_NODE) {
+    globalThis.crypto = require('node:crypto');
+    var chai = require('chai');
+    ({ Calends, CalendarDefinition, TAI64Time, initCalends, stopCalends } = require('./calends'));
+  }
+  else {
+    window.onload = () => {
+      mocha.run();
+    };
+  }
+
+  const beforeFunc = function () {
+    this.timeout(5000);
+    return new Promise((resolve) => {
+      initCalends(resolve);
+    });
+  };
+
+  const afterFunc = function () {
+    this.timeout(5000);
+    return new Promise((resolve) => {
+      stopCalends(resolve);
+    });
+  }
+
+  describe('JS / WASM Tests', function () {
+    after(function () {
+      if (IS_NODE || IS_SHELL) {
+        process.exit();
+      }
+    });
+
+    describe('Calends class', function () {
+      before(beforeFunc);
+      after(afterFunc);
+  
+      describe('constructor', function () {
+        it('creates a valid Calends object', function () {
+          chai.expect(new Calends('0', 'tai64', 'decimal')).instanceof(Calends);
+          chai.expect(new Calends(0, 'unix', '')).instanceof(Calends);
+          chai.expect(new Calends(0.1, 'unix', '')).instanceof(Calends);
+  
+          chai.expect(new Calends({ start: '0', end: '10' }, 'tai64', 'decimal')).instanceof(Calends);
+          chai.expect(new Calends({ start: 0, end: 10 }, 'unix', '')).instanceof(Calends);
+          chai.expect(new Calends({ start: 0.1, end: 9.9 }, 'unix', '')).instanceof(Calends);
+  
+          chai.expect(new Calends({ start: '0', duration: '10' }, 'tai64', 'decimal')).instanceof(Calends);
+          chai.expect(new Calends({ start: 0, duration: 10 }, 'unix', '')).instanceof(Calends);
+          chai.expect(new Calends({ start: 0.1, duration: 9.9 }, 'unix', '')).instanceof(Calends);
+  
+          chai.expect(new Calends({ duration: '0', end: '10' }, 'tai64', 'decimal')).instanceof(Calends);
+          chai.expect(new Calends({ duration: 0, end: 10 }, 'unix', '')).instanceof(Calends);
+          chai.expect(new Calends({ duration: 0.1, end: 9.9 }, 'unix', '')).instanceof(Calends);
+        });
+  
+        it('throws when it fails to create a valid Calends object', function () {
+          chai.expect(() => new Calends([], '', '')).to.throw('Unsupported timestamp type: []');
+        });
+      });
+  
+      describe('fromText', function () {
+        it('creates a valid Calends object', function () {
+          chai.expect(Calends.fromText('0')).instanceof(Calends);
+        });
+      });
+  
+      describe('fromJson', function () {
+        it('creates a valid Calends object', function () {
+          chai.expect(Calends.fromJson('{"start":"0","end":"0"}')).instanceof(Calends);
+        });
+      });
+  
+      describe('date', function () {
+        it('outputs a valid date string', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+  
+          chai.expect(c.date('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('duration', function () {
+        it('outputs a valid duration string', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+  
+          chai.expect(c.duration()).to.equal('0');
+        });
+      });
+  
+      describe('endDate', function () {
+        it('outputs a valid date string', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+  
+          chai.expect(c.endDate('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('toText', function () {
+        it('outputs a valid text value', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+  
+          chai.expect(c.toText()).to.equal('40000000000000000000000000000000000000000000000000000000');
+        });
+      });
+  
+      describe('toJson', function () {
+        it('outputs a valid JSON value', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+  
+          chai.expect(c.toJson()).to.equal('"40000000000000000000000000000000000000000000000000000000"');
+        });
+      });
+  
+      describe('add', function () {
+        it('changes the start date by an offset', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.add('10', 'unix');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('10');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('addFromEnd', function () {
+        it('changes the end date by an offset', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.addFromEnd('10', 'unix');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('subtract', function () {
+        it('changes the start date by an offset', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.subtract('10', 'tai64');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('-10');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('subtractFromEnd', function () {
+        it('changes the end date by an offset', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.subtractFromEnd('10', 'tai64');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('-10');
+        });
+      });
+  
+      describe('next', function () {
+        it('gives the next date interval by an offset', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.next('10', 'tai64');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('previous', function () {
+        it('gives the previous date interval by an offset', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.previous('10', 'tai64');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('-10');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('withDate', function () {
+        it('sets the start date to a specific instant', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.withDate('10', 'tai64', 'decimal');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('10');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('withEndDate', function () {
+        it('sets the end date to a specific instant', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.withEndDate('10', 'tai64', 'decimal');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('withDuration', function () {
+        it('sets the duration to a specific length from the start', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.withDuration('10', 'tai64');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('withDurationFromEnd', function () {
+        it('sets the duration to a specific length from the end', function () {
+          const c = new Calends('0', 'tai64', 'decimal');
+          const z = c.withDurationFromEnd('10', 'tai64', 'decimal');
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('-10');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('0');
+        });
+      });
+  
+      describe('merge', function () {
+        it('merges two moments', function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends('10', 'tai64', 'decimal');
+          const z = a.merge(b);
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('intersect', function () {
+        it('finds the moment shared by two other moments', function () {
+          const a = new Calends({start: '0', end: '10'}, 'tai64', 'decimal');
+          const b = new Calends('10', 'tai64', 'decimal');
+          const z = a.intersect(b);
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('10');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('gap', function () {
+        it('finds the moment between two other moments', function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends('10', 'tai64', 'decimal');
+          const z = a.gap(b);
+  
+          chai.expect(z).instanceof(Calends);
+          chai.expect(z.date('tai64', 'decimal')).to.equal('0');
+          chai.expect(z.endDate('tai64', 'decimal')).to.equal('10');
+        });
+      });
+  
+      describe('difference', function () {
+        it("finds the difference between two moments' instants", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends('10', 'tai64', 'decimal');
+  
+          chai.expect(a.difference(b, 'start')).to.equal('-10');
+          chai.expect(a.difference(b, 'start-end')).to.equal('-10');
+          chai.expect(a.difference(b, 'end-start')).to.equal('-10');
+          chai.expect(a.difference(b, 'end')).to.equal('-10');
+          chai.expect(a.difference(b, 'duration')).to.equal('0');
+  
+          chai.expect(b.difference(a, 'start')).to.equal('10');
+          chai.expect(b.difference(a, 'start-end')).to.equal('10');
+          chai.expect(b.difference(a, 'end-start')).to.equal('10');
+          chai.expect(b.difference(a, 'end')).to.equal('10');
+          chai.expect(b.difference(a, 'duration')).to.equal('0');
+        });
+      });
+  
+      describe('compare', function () {
+        it("compares two moments' instants", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends('10', 'tai64', 'decimal');
+  
+          chai.expect(a.compare(b, 'start')).to.equal(-1);
+          chai.expect(a.compare(b, 'start-end')).to.equal(-1);
+          chai.expect(a.compare(b, 'end-start')).to.equal(-1);
+          chai.expect(a.compare(b, 'end')).to.equal(-1);
+          chai.expect(a.compare(b, 'duration')).to.equal(0);
+  
+          chai.expect(b.compare(a, 'start')).to.equal(1);
+          chai.expect(b.compare(a, 'start-end')).to.equal(1);
+          chai.expect(b.compare(a, 'end-start')).to.equal(1);
+          chai.expect(b.compare(a, 'end')).to.equal(1);
+          chai.expect(b.compare(a, 'duration')).to.equal(0);
+        });
+      });
+  
+      describe('isSame', function () {
+        it("checks whether two moments are identical", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends('10', 'tai64', 'decimal');
+          const c = new Calends('10', 'tai64', 'decimal');
+  
+          chai.expect(a.isSame(a)).true;
+          chai.expect(a.isSame(b)).false;
+          chai.expect(a.isSame(c)).false;
+  
+          chai.expect(b.isSame(a)).false;
+          chai.expect(b.isSame(b)).true;
+          chai.expect(b.isSame(c)).true;
+  
+          chai.expect(c.isSame(a)).false;
+          chai.expect(c.isSame(b)).true;
+          chai.expect(c.isSame(c)).true;
+        });
+      });
+  
+      describe('isSameDuration', function () {
+        it("checks whether two moments have the same duration", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.isSameDuration(a)).true;
+          chai.expect(a.isSameDuration(b)).false;
+          chai.expect(a.isSameDuration(c)).false;
+  
+          chai.expect(b.isSameDuration(a)).false;
+          chai.expect(b.isSameDuration(b)).true;
+          chai.expect(b.isSameDuration(c)).true;
+  
+          chai.expect(c.isSameDuration(a)).false;
+          chai.expect(c.isSameDuration(b)).true;
+          chai.expect(c.isSameDuration(c)).true;
+        });
+      });
+  
+      describe('isShorter', function () {
+        it("checks whether one moment is shorter than another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.isShorter(a)).false;
+          chai.expect(a.isShorter(b)).true;
+          chai.expect(a.isShorter(c)).true;
+  
+          chai.expect(b.isShorter(a)).false;
+          chai.expect(b.isShorter(b)).false;
+          chai.expect(b.isShorter(c)).false;
+  
+          chai.expect(c.isShorter(a)).false;
+          chai.expect(c.isShorter(b)).false;
+          chai.expect(c.isShorter(c)).false;
+        });
+      });
+  
+      describe('isLonger', function () {
+        it("checks whether one moment is longer than another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.isLonger(a)).false;
+          chai.expect(a.isLonger(b)).false;
+          chai.expect(a.isLonger(c)).false;
+  
+          chai.expect(b.isLonger(a)).true;
+          chai.expect(b.isLonger(b)).false;
+          chai.expect(b.isLonger(c)).false;
+  
+          chai.expect(c.isLonger(a)).true;
+          chai.expect(c.isLonger(b)).false;
+          chai.expect(c.isLonger(c)).false;
+        });
+      });
+  
+      describe('isBefore', function () {
+        it("checks whether one moment is before another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.isBefore(a)).false;
+          chai.expect(a.isBefore(b)).true;
+          chai.expect(a.isBefore(c)).false;
+  
+          chai.expect(b.isBefore(a)).false;
+          chai.expect(b.isBefore(b)).false;
+          chai.expect(b.isBefore(c)).false;
+  
+          chai.expect(c.isBefore(a)).false;
+          chai.expect(c.isBefore(b)).true;
+          chai.expect(c.isBefore(c)).false;
+        });
+      });
+  
+      describe('isDuring', function () {
+        it("checks whether one moment is during another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.isDuring(a)).true;
+          chai.expect(a.isDuring(b)).false;
+          chai.expect(a.isDuring(c)).true;
+  
+          chai.expect(b.isDuring(a)).false;
+          chai.expect(b.isDuring(b)).true;
+          chai.expect(b.isDuring(c)).false;
+  
+          chai.expect(c.isDuring(a)).false;
+          chai.expect(c.isDuring(b)).false;
+          chai.expect(c.isDuring(c)).true;
+        });
+      });
+  
+      describe('isAfter', function () {
+        it("checks whether one moment is after another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.isAfter(a)).false;
+          chai.expect(a.isAfter(b)).false;
+          chai.expect(a.isAfter(c)).false;
+  
+          chai.expect(b.isAfter(a)).true;
+          chai.expect(b.isAfter(b)).false;
+          chai.expect(b.isAfter(c)).true;
+  
+          chai.expect(c.isAfter(a)).true;
+          chai.expect(c.isAfter(b)).false;
+          chai.expect(c.isAfter(c)).false;
+        });
+      });
+  
+      describe('startsBefore', function () {
+        it("checks whether one moment starts before another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.startsBefore(a)).false;
+          chai.expect(a.startsBefore(b)).true;
+          chai.expect(a.startsBefore(c)).false;
+  
+          chai.expect(b.startsBefore(a)).false;
+          chai.expect(b.startsBefore(b)).false;
+          chai.expect(b.startsBefore(c)).false;
+  
+          chai.expect(c.startsBefore(a)).false;
+          chai.expect(c.startsBefore(b)).true;
+          chai.expect(c.startsBefore(c)).false;
+        });
+      });
+  
+      describe('startsDuring', function () {
+        it("checks whether one moment starts during another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.startsDuring(a)).true;
+          chai.expect(a.startsDuring(b)).false;
+          chai.expect(a.startsDuring(c)).true;
+  
+          chai.expect(b.startsDuring(a)).false;
+          chai.expect(b.startsDuring(b)).true;
+          chai.expect(b.startsDuring(c)).false;
+  
+          chai.expect(c.startsDuring(a)).false;
+          chai.expect(c.startsDuring(b)).false;
+          chai.expect(c.startsDuring(c)).true;
+        });
+      });
+  
+      describe('startsAfter', function () {
+        it("checks whether one moment starts after another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.startsAfter(a)).false;
+          chai.expect(a.startsAfter(b)).false;
+          chai.expect(a.startsAfter(c)).false;
+  
+          chai.expect(b.startsAfter(a)).true;
+          chai.expect(b.startsAfter(b)).false;
+          chai.expect(b.startsAfter(c)).true;
+  
+          chai.expect(c.startsAfter(a)).false;
+          chai.expect(c.startsAfter(b)).false;
+          chai.expect(c.startsAfter(c)).false;
+        });
+      });
+  
+      describe('endsBefore', function () {
+        it("checks whether one moment ends before another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.endsBefore(a)).false;
+          chai.expect(a.endsBefore(b)).true;
+          chai.expect(a.endsBefore(c)).true;
+  
+          chai.expect(b.endsBefore(a)).false;
+          chai.expect(b.endsBefore(b)).false;
+          chai.expect(b.endsBefore(c)).false;
+  
+          chai.expect(c.endsBefore(a)).false;
+          chai.expect(c.endsBefore(b)).true;
+          chai.expect(c.endsBefore(c)).false;
+        });
+      });
+  
+      describe('endsDuring', function () {
+        it("checks whether one moment ends during another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.endsDuring(a)).true;
+          chai.expect(a.endsDuring(b)).false;
+          chai.expect(a.endsDuring(c)).true;
+  
+          chai.expect(b.endsDuring(a)).false;
+          chai.expect(b.endsDuring(b)).true;
+          chai.expect(b.endsDuring(c)).false;
+  
+          chai.expect(c.endsDuring(a)).false;
+          chai.expect(c.endsDuring(b)).false;
+          chai.expect(c.endsDuring(c)).true;
+        });
+      });
+  
+      describe('endsAfter', function () {
+        it("checks whether one moment ends after another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.endsAfter(a)).false;
+          chai.expect(a.endsAfter(b)).false;
+          chai.expect(a.endsAfter(c)).false;
+  
+          chai.expect(b.endsAfter(a)).true;
+          chai.expect(b.endsAfter(b)).false;
+          chai.expect(b.endsAfter(c)).true;
+  
+          chai.expect(c.endsAfter(a)).true;
+          chai.expect(c.endsAfter(b)).false;
+          chai.expect(c.endsAfter(c)).false;
+        });
+      });
+  
+      describe('contains', function () {
+        it("checks whether one moment contains another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.contains(a)).true;
+          chai.expect(a.contains(b)).false;
+          chai.expect(a.contains(c)).false;
+  
+          chai.expect(b.contains(a)).false;
+          chai.expect(b.contains(b)).true;
+          chai.expect(b.contains(c)).false;
+  
+          chai.expect(c.contains(a)).true;
+          chai.expect(c.contains(b)).false;
+          chai.expect(c.contains(c)).true;
+        });
+      });
+  
+      describe('overlaps', function () {
+        it("checks whether one moment overlaps with another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.overlaps(a)).true;
+          chai.expect(a.overlaps(b)).false;
+          chai.expect(a.overlaps(c)).true;
+  
+          chai.expect(b.overlaps(a)).false;
+          chai.expect(b.overlaps(b)).true;
+          chai.expect(b.overlaps(c)).false;
+  
+          chai.expect(c.overlaps(a)).true;
+          chai.expect(c.overlaps(b)).false;
+          chai.expect(c.overlaps(c)).true;
+        });
+      });
+  
+      describe('abuts', function () {
+        it("checks whether one moment is next to another", function () {
+          const a = new Calends('0', 'tai64', 'decimal');
+          const b = new Calends({ start: '10', end: '20' }, 'tai64', 'decimal');
+          const c = new Calends({ start: '0', end: '10' }, 'tai64', 'decimal');
+  
+          chai.expect(a.abuts(a)).false;
+          chai.expect(a.abuts(b)).false;
+          chai.expect(a.abuts(c)).false;
+  
+          chai.expect(b.abuts(a)).false;
+          chai.expect(b.abuts(b)).false;
+          chai.expect(b.abuts(c)).true;
+  
+          chai.expect(c.abuts(a)).false;
+          chai.expect(c.abuts(b)).true;
+          chai.expect(c.abuts(c)).false;
+        });
+      });
+    });
+  
+    describe('TAI64TIme class', function () {
+      before(beforeFunc);
+      after(afterFunc);
+  
+      describe('constructor', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = new TAI64Time();
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.seconds).to.equal(0);
+        });
+      });
+  
+      describe('fromString', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromString('0');
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.seconds).to.equal(0);
+        });
+      });
+  
+      describe('fromHex', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromHex('0');
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.seconds).to.equal(-4611686018427388000);
+        });
+      });
+  
+      describe('fromNumber', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromNumber(0);
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.seconds).to.equal(0);
+        });
+      });
+  
+      describe('fromText', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromText('0');
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.seconds).to.equal(-4611686018427388000);
+        });
+      });
+  
+      describe('toString', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromString('0');
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.toString()).to.equal('0');
+        });
+      });
+  
+      describe('toHex', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromHex('0');
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.toHex()).to.equal('00000000000000000000000000000000000000000000000000000000');
+        });
+      });
+  
+      describe('toNumber', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromNumber(0);
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.toNumber()).to.equal(0);
+        });
+      });
+  
+      describe('toText', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromText('0');
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.toText()).to.equal('00000000000000000000000000000000000000000000000000000000');
+        });
+      });
+  
+      describe('add', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromNumber(0);
+          const z = TAI64Time.fromNumber(16);
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(z).instanceof(TAI64Time);
+          chai.expect(t.add(z).toHex()).to.equal('40000000000000100000000000000000000000000000000000000000');
+        });
+      });
+  
+      describe('sub', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromNumber(0);
+          const z = TAI64Time.fromNumber(16);
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(z).instanceof(TAI64Time);
+          chai.expect(t.sub(z).toHex()).to.equal('3FFFFFFFFFFFFFF00000000000000000000000000000000000000000');
+        });
+      });
+  
+      describe('fromUTC', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromNumber(0);
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.fromUTC().toHex()).to.equal('3FFFFFFFFFFFFFF93B747D4F3B9AC9F32E697BF03735DCC300FE4046');
+        });
+      });
+  
+      describe('toUTC', function () {
+        it('creates a valid TAI64Time object', function () {
+          const t = TAI64Time.fromNumber(0);
+  
+          chai.expect(t).instanceof(TAI64Time);
+          chai.expect(t.toUTC().toHex()).to.equal('40000000000000080001404F3B9AC633119BB28532DB8E0D3399E120');
+        });
+      });
+    });
+  
+    describe('CalendarDefinition interface (abstract class, really)', function () {
+      before(beforeFunc);
+      after(afterFunc);
+  
+      it('constructor (should fail)', function () {
+        chai.expect(() => new CalendarDefinition()).throws("Don't directly create a CalendarDefinition object - use a subclass instead")
+      });
+  
+      it('checkRegistered', function () {
+        chai.expect(CalendarDefinition.checkRegistered('unix')).true;
+        chai.expect(CalendarDefinition.checkRegistered('invalid')).false;
+      });
+  
+      it('registered', function () {
+        chai.expect(CalendarDefinition.registered()).to.deep.equal(['Gregorian', 'Jdc', 'Stardate', 'Tai64', 'Unix']);
+      });
+    });
+  
+    describe('FakeCalendar class', function () {
+      class FakeCalendar extends CalendarDefinition {
+        name = 'fake';
+        defaultFormat = '';
+  
+        toInternal(stamp, format) {
+          return new TAI64Time({ seconds: 0 });
+        }
+  
+        fromInternal(instant, format) {
+          return `${this.name}:0:${format}`;
+        }
+  
+        offset(instant, offset) {
+          return instant;
+        }
+      }
+  
+      before(beforeFunc);
+      after(afterFunc);
+  
+      it('constructor (should succeed)', function () {
+        const c = new FakeCalendar();
+  
+        chai.expect(c).instanceof(CalendarDefinition);
+        chai.expect(c).instanceof(FakeCalendar);
+      });
+  
+      it('register/unregister/isRegistered', function () {
+        const c = new FakeCalendar();
+  
+        chai.expect(c).instanceof(CalendarDefinition);
+        chai.expect(c).instanceof(FakeCalendar);
+        chai.expect(FakeCalendar.checkRegistered(c.name)).false;
+        chai.expect(c.isRegistered()).false;
+  
+        c.register();
+  
+        chai.expect(FakeCalendar.checkRegistered(c.name)).true;
+        chai.expect(c.isRegistered()).true;
+  
+        c.unregister();
+  
+        chai.expect(FakeCalendar.checkRegistered(c.name)).false;
+        chai.expect(c.isRegistered()).false;
+      });
+  
+      it('toInternal', function () {
+        const c = new FakeCalendar();
+  
+        chai.expect(c).instanceof(CalendarDefinition);
+        chai.expect(c).instanceof(FakeCalendar);
+  
+        chai.expect(c.toInternal('', '')).instanceof(TAI64Time);
+      });
+  
+      it('fromInternal', function () {
+        const c = new FakeCalendar();
+  
+        chai.expect(c).instanceof(CalendarDefinition);
+        chai.expect(c).instanceof(FakeCalendar);
+  
+        chai.expect(c.fromInternal(new TAI64Time(), '')).to.equal('fake:0:');
+      });
+  
+      it('offset', function () {
+        const c = new FakeCalendar();
+  
+        chai.expect(c).instanceof(CalendarDefinition);
+        chai.expect(c).instanceof(FakeCalendar);
+  
+        chai.expect(c.offset(new TAI64Time(), '')).instanceof(TAI64Time);
+      });
+    });
+  });
+}

--- a/wasm/js/wasm_loader.js
+++ b/wasm/js/wasm_loader.js
@@ -1,0 +1,554 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+"use strict";
+
+(() => {
+	const enosys = () => {
+		const err = new Error("not implemented");
+		err.code = "ENOSYS";
+		return err;
+	};
+
+	if (!globalThis.fs) {
+		let outputBuf = "";
+		globalThis.fs = {
+			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1 }, // unused
+			writeSync(fd, buf) {
+				outputBuf += decoder.decode(buf);
+				const nl = outputBuf.lastIndexOf("\n");
+				if (nl != -1) {
+					console.log(outputBuf.substr(0, nl));
+					outputBuf = outputBuf.substr(nl + 1);
+				}
+				return buf.length;
+			},
+			write(fd, buf, offset, length, position, callback) {
+				if (offset !== 0 || length !== buf.length || position !== null) {
+					callback(enosys());
+					return;
+				}
+				const n = this.writeSync(fd, buf);
+				callback(null, n);
+			},
+			chmod(path, mode, callback) { callback(enosys()); },
+			chown(path, uid, gid, callback) { callback(enosys()); },
+			close(fd, callback) { callback(enosys()); },
+			fchmod(fd, mode, callback) { callback(enosys()); },
+			fchown(fd, uid, gid, callback) { callback(enosys()); },
+			fstat(fd, callback) { callback(enosys()); },
+			fsync(fd, callback) { callback(null); },
+			ftruncate(fd, length, callback) { callback(enosys()); },
+			lchown(path, uid, gid, callback) { callback(enosys()); },
+			link(path, link, callback) { callback(enosys()); },
+			lstat(path, callback) { callback(enosys()); },
+			mkdir(path, perm, callback) { callback(enosys()); },
+			open(path, flags, mode, callback) { callback(enosys()); },
+			read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
+			readdir(path, callback) { callback(enosys()); },
+			readlink(path, callback) { callback(enosys()); },
+			rename(from, to, callback) { callback(enosys()); },
+			rmdir(path, callback) { callback(enosys()); },
+			stat(path, callback) { callback(enosys()); },
+			symlink(path, link, callback) { callback(enosys()); },
+			truncate(path, length, callback) { callback(enosys()); },
+			unlink(path, callback) { callback(enosys()); },
+			utimes(path, atime, mtime, callback) { callback(enosys()); },
+		};
+	}
+
+	if (!globalThis.process) {
+		globalThis.process = {
+			getuid() { return -1; },
+			getgid() { return -1; },
+			geteuid() { return -1; },
+			getegid() { return -1; },
+			getgroups() { throw enosys(); },
+			pid: -1,
+			ppid: -1,
+			umask() { throw enosys(); },
+			cwd() { throw enosys(); },
+			chdir() { throw enosys(); },
+		}
+	}
+
+	if (!globalThis.crypto) {
+		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");
+	}
+
+	if (!globalThis.performance) {
+		throw new Error("globalThis.performance is not available, polyfill required (performance.now only)");
+	}
+
+	if (!globalThis.TextEncoder) {
+		throw new Error("globalThis.TextEncoder is not available, polyfill required");
+	}
+
+	if (!globalThis.TextDecoder) {
+		throw new Error("globalThis.TextDecoder is not available, polyfill required");
+	}
+
+	const encoder = new TextEncoder("utf-8");
+	const decoder = new TextDecoder("utf-8");
+
+	globalThis.Go = class {
+		constructor() {
+			this.argv = ["js"];
+			this.env = {};
+			this.exit = (code) => {
+				if (code !== 0) {
+					console.warn("exit code:", code);
+				}
+			};
+			this._exitPromise = new Promise((resolve) => {
+				this._resolveExitPromise = resolve;
+			});
+			this._pendingEvent = null;
+			this._scheduledTimeouts = new Map();
+			this._nextCallbackTimeoutID = 1;
+
+			const setInt64 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
+			}
+
+			const getInt64 = (addr) => {
+				const low = this.mem.getUint32(addr + 0, true);
+				const high = this.mem.getInt32(addr + 4, true);
+				return low + high * 4294967296;
+			}
+
+			const loadValue = (addr) => {
+				const f = this.mem.getFloat64(addr, true);
+				if (f === 0) {
+					return undefined;
+				}
+				if (!isNaN(f)) {
+					return f;
+				}
+
+				const id = this.mem.getUint32(addr, true);
+				return this._values[id];
+			}
+
+			const storeValue = (addr, v) => {
+				const nanHead = 0x7FF80000;
+
+				if (typeof v === "number" && v !== 0) {
+					if (isNaN(v)) {
+						this.mem.setUint32(addr + 4, nanHead, true);
+						this.mem.setUint32(addr, 0, true);
+						return;
+					}
+					this.mem.setFloat64(addr, v, true);
+					return;
+				}
+
+				if (v === undefined) {
+					this.mem.setFloat64(addr, 0, true);
+					return;
+				}
+
+				let id = this._ids.get(v);
+				if (id === undefined) {
+					id = this._idPool.pop();
+					if (id === undefined) {
+						id = this._values.length;
+					}
+					this._values[id] = v;
+					this._goRefCounts[id] = 0;
+					this._ids.set(v, id);
+				}
+				this._goRefCounts[id]++;
+				let typeFlag = 0;
+				switch (typeof v) {
+					case "object":
+						if (v !== null) {
+							typeFlag = 1;
+						}
+						break;
+					case "string":
+						typeFlag = 2;
+						break;
+					case "symbol":
+						typeFlag = 3;
+						break;
+					case "function":
+						typeFlag = 4;
+						break;
+				}
+				this.mem.setUint32(addr + 4, nanHead | typeFlag, true);
+				this.mem.setUint32(addr, id, true);
+			}
+
+			const loadSlice = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+			}
+
+			const loadSliceOfValues = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				const a = new Array(len);
+				for (let i = 0; i < len; i++) {
+					a[i] = loadValue(array + i * 8);
+				}
+				return a;
+			}
+
+			const loadString = (addr) => {
+				const saddr = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
+			}
+
+			const timeOrigin = Date.now() - performance.now();
+			this.importObject = {
+				go: {
+					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
+					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
+					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
+					// This changes the SP, thus we have to update the SP used by the imported function.
+
+					// func wasmExit(code int32)
+					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
+						const code = this.mem.getInt32(sp + 8, true);
+						this.exited = true;
+						delete this._inst;
+						delete this._values;
+						delete this._goRefCounts;
+						delete this._ids;
+						delete this._idPool;
+						this.exit(code);
+					},
+
+					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
+					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
+						const fd = getInt64(sp + 8);
+						const p = getInt64(sp + 16);
+						const n = this.mem.getInt32(sp + 24, true);
+						fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+					},
+
+					// func resetMemoryDataView()
+					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
+						this.mem = new DataView(this._inst.exports.mem.buffer);
+					},
+
+					// func nanotime1() int64
+					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
+					},
+
+					// func walltime() (sec int64, nsec int32)
+					"runtime.walltime": (sp) => {
+						sp >>>= 0;
+						const msec = (new Date).getTime();
+						setInt64(sp + 8, msec / 1000);
+						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
+					},
+
+					// func scheduleTimeoutEvent(delay int64) int32
+					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this._nextCallbackTimeoutID;
+						this._nextCallbackTimeoutID++;
+						this._scheduledTimeouts.set(id, setTimeout(
+							() => {
+								this._resume();
+								while (this._scheduledTimeouts.has(id)) {
+									// for some reason Go failed to register the timeout event, log and try again
+									// (temporary workaround for https://github.com/golang/go/issues/28975)
+									console.warn("scheduleTimeoutEvent: missed timeout event");
+									this._resume();
+								}
+							},
+							getInt64(sp + 8) + 1, // setTimeout has been seen to fire up to 1 millisecond early
+						));
+						this.mem.setInt32(sp + 16, id, true);
+					},
+
+					// func clearTimeoutEvent(id int32)
+					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getInt32(sp + 8, true);
+						clearTimeout(this._scheduledTimeouts.get(id));
+						this._scheduledTimeouts.delete(id);
+					},
+
+					// func getRandomData(r []byte)
+					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
+						crypto.getRandomValues(loadSlice(sp + 8));
+					},
+
+					// func finalizeRef(v ref)
+					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getUint32(sp + 8, true);
+						this._goRefCounts[id]--;
+						if (this._goRefCounts[id] === 0) {
+							const v = this._values[id];
+							this._values[id] = null;
+							this._ids.delete(v);
+							this._idPool.push(id);
+						}
+					},
+
+					// func stringVal(value string) ref
+					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, loadString(sp + 8));
+					},
+
+					// func valueGet(v ref, p string) ref
+					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
+						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
+						storeValue(sp + 32, result);
+					},
+
+					// func valueSet(v ref, p string, x ref)
+					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
+					},
+
+					// func valueDelete(v ref, p string)
+					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
+						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
+					},
+
+					// func valueIndex(v ref, i int) ref
+					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
+					},
+
+					// valueSetIndex(v ref, i int, x ref)
+					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
+					},
+
+					// func valueCall(v ref, m string, args []ref) (ref, bool)
+					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const m = Reflect.get(v, loadString(sp + 16));
+							const args = loadSliceOfValues(sp + 32);
+							const result = Reflect.apply(m, v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, result);
+							this.mem.setUint8(sp + 64, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, err);
+							this.mem.setUint8(sp + 64, 0);
+						}
+					},
+
+					// func valueInvoke(v ref, args []ref) (ref, bool)
+					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.apply(v, undefined, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueNew(v ref, args []ref) (ref, bool)
+					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.construct(v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueLength(v ref) int
+					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
+					},
+
+					// valuePrepareString(v ref) (ref, int)
+					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
+						const str = encoder.encode(String(loadValue(sp + 8)));
+						storeValue(sp + 16, str);
+						setInt64(sp + 24, str.length);
+					},
+
+					// valueLoadString(v ref, b []byte)
+					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
+						const str = loadValue(sp + 8);
+						loadSlice(sp + 16).set(str);
+					},
+
+					// func valueInstanceOf(v ref, t ref) bool
+					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
+						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
+					},
+
+					// func copyBytesToGo(dst []byte, src ref) (int, bool)
+					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
+						const dst = loadSlice(sp + 8);
+						const src = loadValue(sp + 32);
+						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					// func copyBytesToJS(dst ref, src []byte) (int, bool)
+					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
+						const dst = loadValue(sp + 8);
+						const src = loadSlice(sp + 16);
+						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					"debug": (value) => {
+						console.log(value);
+					},
+				}
+			};
+		}
+
+		async run(instance) {
+			if (!(instance instanceof WebAssembly.Instance)) {
+				throw new Error("Go.run: WebAssembly.Instance expected");
+			}
+			this._inst = instance;
+			this.mem = new DataView(this._inst.exports.mem.buffer);
+			this._values = [ // JS values that Go currently has references to, indexed by reference id
+				NaN,
+				0,
+				null,
+				true,
+				false,
+				globalThis,
+				this,
+			];
+			this._goRefCounts = new Array(this._values.length).fill(Infinity); // number of references that Go has to a JS value, indexed by reference id
+			this._ids = new Map([ // mapping from JS values to reference ids
+				[0, 1],
+				[null, 2],
+				[true, 3],
+				[false, 4],
+				[globalThis, 5],
+				[this, 6],
+			]);
+			this._idPool = [];   // unused ids that have been garbage collected
+			this.exited = false; // whether the Go program has exited
+
+			// Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
+			let offset = 4096;
+
+			const strPtr = (str) => {
+				const ptr = offset;
+				const bytes = encoder.encode(str + "\0");
+				new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes);
+				offset += bytes.length;
+				if (offset % 8 !== 0) {
+					offset += 8 - (offset % 8);
+				}
+				return ptr;
+			};
+
+			const argc = this.argv.length;
+
+			const argvPtrs = [];
+			this.argv.forEach((arg) => {
+				argvPtrs.push(strPtr(arg));
+			});
+			argvPtrs.push(0);
+
+			const keys = Object.keys(this.env).sort();
+			keys.forEach((key) => {
+				argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+			});
+			argvPtrs.push(0);
+
+			const argv = offset;
+			argvPtrs.forEach((ptr) => {
+				this.mem.setUint32(offset, ptr, true);
+				this.mem.setUint32(offset + 4, 0, true);
+				offset += 8;
+			});
+
+			// The linker guarantees global data starts from at least wasmMinDataAddr.
+			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
+			const wasmMinDataAddr = 4096 + 8192;
+			if (offset >= wasmMinDataAddr) {
+				throw new Error("total length of command line and environment variables exceeds limit");
+			}
+
+			this._inst.exports.run(argc, argv);
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+			await this._exitPromise;
+		}
+
+		_resume() {
+			if (this.exited) {
+				throw new Error("Go program has already exited");
+			}
+			this._inst.exports.resume();
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+		}
+
+		_makeFuncWrapper(id) {
+			const go = this;
+			return function () {
+				const event = { id: id, this: this, args: arguments };
+				go._pendingEvent = event;
+				go._resume();
+				return event.result;
+			};
+		}
+	}
+})();

--- a/wasm/offsets.go
+++ b/wasm/offsets.go
@@ -1,0 +1,380 @@
+//go:build js && wasm
+
+package main
+
+import "syscall/js"
+
+func calendsAdd(p uint64, offset interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.Add(offset, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsAddString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].String()
+	calendar := args[2].String()
+
+	return calendsAdd(p, offset, calendar)
+}
+
+func CalendsAddInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsAdd(p, offset, calendar)
+}
+
+func CalendsAddDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsAdd(p, offset, calendar)
+}
+
+func calendsSubtract(p uint64, offset interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.Subtract(offset, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsSubtractString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].String()
+	calendar := args[2].String()
+
+	return calendsSubtract(p, offset, calendar)
+}
+
+func CalendsSubtractInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsSubtract(p, offset, calendar)
+}
+
+func CalendsSubtractDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsSubtract(p, offset, calendar)
+}
+
+func calendsAddFromEnd(p uint64, offset interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.AddFromEnd(offset, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsAddFromEndString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].String()
+	calendar := args[2].String()
+
+	return calendsAddFromEnd(p, offset, calendar)
+}
+
+func CalendsAddFromEndInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsAddFromEnd(p, offset, calendar)
+}
+
+func CalendsAddFromEndDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsAddFromEnd(p, offset, calendar)
+}
+
+func calendsSubtractFromEnd(p uint64, offset interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.SubtractFromEnd(offset, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsSubtractFromEndString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].String()
+	calendar := args[2].String()
+
+	return calendsSubtractFromEnd(p, offset, calendar)
+}
+
+func CalendsSubtractFromEndInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsSubtractFromEnd(p, offset, calendar)
+}
+
+func CalendsSubtractFromEndDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsSubtractFromEnd(p, offset, calendar)
+}
+
+func calendsNext(p uint64, offset interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.Next(offset, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsNextString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].String()
+	calendar := args[2].String()
+
+	return calendsNext(p, offset, calendar)
+}
+
+func CalendsNextInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsNext(p, offset, calendar)
+}
+
+func CalendsNextDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsNext(p, offset, calendar)
+}
+
+func calendsPrevious(p uint64, offset interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.Previous(offset, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsPreviousString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].String()
+	calendar := args[2].String()
+
+	return calendsPrevious(p, offset, calendar)
+}
+
+func CalendsPreviousInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsPrevious(p, offset, calendar)
+}
+
+func CalendsPreviousDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	offset := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsPrevious(p, offset, calendar)
+}
+
+func calendsWithDate(p uint64, stamp interface{}, calendar, format string) js.Value {
+	c := instGet(p)
+	out, err := c.SetDate(stamp, calendar, format)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsWithDateString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	stamp := args[1].String()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return calendsWithDate(p, stamp, calendar, format)
+}
+
+func CalendsWithDateInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	stamp := args[1].Int()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return calendsWithDate(p, stamp, calendar, format)
+}
+
+func CalendsWithDateDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	stamp := args[1].Float()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return calendsWithDate(p, stamp, calendar, format)
+}
+
+func calendsWithEndDate(p uint64, stamp interface{}, calendar, format string) js.Value {
+	c := instGet(p)
+	out, err := c.SetEndDate(stamp, calendar, format)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsWithEndDateString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	stamp := args[1].String()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return calendsWithEndDate(p, stamp, calendar, format)
+}
+
+func CalendsWithEndDateInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	stamp := args[1].Int()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return calendsWithEndDate(p, stamp, calendar, format)
+}
+
+func CalendsWithEndDateDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	stamp := args[1].Float()
+	calendar := args[2].String()
+	format := args[3].String()
+
+	return calendsWithEndDate(p, stamp, calendar, format)
+}
+
+func calendsWithDuration(p uint64, duration interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.SetDuration(duration, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsWithDurationString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	duration := args[1].String()
+	calendar := args[2].String()
+
+	return calendsWithDuration(p, duration, calendar)
+}
+
+func CalendsWithDurationInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	duration := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsWithDuration(p, duration, calendar)
+}
+
+func CalendsWithDurationDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	duration := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsWithDuration(p, duration, calendar)
+}
+
+func calendsWithDurationFromEnd(p uint64, duration interface{}, calendar string) js.Value {
+	c := instGet(p)
+	out, err := c.SetDurationFromEnd(duration, calendar)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsWithDurationFromEndString(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	duration := args[1].String()
+	calendar := args[2].String()
+
+	return calendsWithDurationFromEnd(p, duration, calendar)
+}
+
+func CalendsWithDurationFromEndInt64(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	duration := args[1].Int()
+	calendar := args[2].String()
+
+	return calendsWithDurationFromEnd(p, duration, calendar)
+}
+
+func CalendsWithDurationFromEndDouble(this js.Value, args []js.Value) interface{} {
+	p := uint64(args[0].Int())
+	duration := args[1].Float()
+	calendar := args[2].String()
+
+	return calendsWithDurationFromEnd(p, duration, calendar)
+}
+
+func CalendsMerge(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	out, err := c.Merge(*z)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsIntersect(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	out, err := c.Intersect(*z)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}
+
+func CalendsGap(this js.Value, args []js.Value) interface{} {
+	p1 := uint64(args[0].Int())
+	p2 := uint64(args[1].Int())
+
+	c := instGet(p1)
+	z := instGet(p2)
+	out, err := c.Gap(*z)
+	if err != nil {
+		panic(err)
+	}
+	return js.ValueOf(instNum(out))
+}


### PR DESCRIPTION
Go's WASM support is very ... weird. Instead of `export`ing functions for use by JS, it requires that you _register_ them into the global namespace. So I built a wrapper class around that approach, to be refactored according to proper WASM/WASI specs as soon as Go supports that (or TinyGo supports all the Go language features we use internally to make everything work).

This change adds the WASM library and the JS wrapper class. From here, browsers can make use of the library in a clean and safe manner.

The other thing it does is rename TAI64NAXUR to TAI64NARUX, because the folks in charge of SI prefixes have defined a couple of new ones that required shuffling things around a bit. Xictoseconds are now Rontoseconds, in accordance with international standards, while Uctoseconds are now Udectoseconds, and Roctoseconds are now Xindectoseconds. This change shouldn't affect any users of the library who haven't created their own calendar systems for it, but does make fairly extensive changes to the library itself to support the renames. That does mean this is a breaking change for developers, requiring a version bump from v0.0.5 to v0.1.0 to reflect that reality.